### PR TITLE
Implement -print-dest-src-operands; Handle TEST8mi MIR

### DIFF
--- a/llvm-10.0.1/llvm-crash-analyzer/include/Analysis/TaintAnalysis.h
+++ b/llvm-10.0.1/llvm-crash-analyzer/include/Analysis/TaintAnalysis.h
@@ -101,7 +101,7 @@ public:
   bool addToTaintList(TaintInfo &Ti, SmallVectorImpl<TaintInfo> &TL);
   void printTaintList(SmallVectorImpl<TaintInfo> &TL);
   void printTaintList2(SmallVectorImpl<TaintInfo> &TL);
-  void printDestSrcInfo(DestSourcePair &DS);
+  void printDestSrcInfo(DestSourcePair &DS, const MachineInstr &MI);
   bool shouldAnalyzeCall(SmallVectorImpl<TaintInfo> &TL);
   TaintInfo isTainted(TaintInfo &Op, SmallVectorImpl<TaintInfo> &TL,
                       RegisterEquivalence *REAnalysis = nullptr,

--- a/llvm-10.0.1/llvm-crash-analyzer/lib/Analysis/TaintAnalysis.cpp
+++ b/llvm-10.0.1/llvm-crash-analyzer/lib/Analysis/TaintAnalysis.cpp
@@ -425,42 +425,40 @@ void crash_analyzer::TaintAnalysis::printDestSrcInfo(DestSourcePair &DestSrc,
   if (!PrintDestSrcOperands && !isDebug())
     return;
 
-  MI.dump();
+  const auto &MF = MI.getParent()->getParent();
+  auto TRI = MF->getSubtarget().getRegisterInfo();
 
+  MI.dump();
   if (DestSrc.Destination) {
-    llvm::dbgs() << "Destination: ";
-    DestSrc.Destination->dump();
+    llvm::dbgs() << "Dest {reg:"
+                 << printReg(DestSrc.Destination->getReg(), TRI);
     if (DestSrc.DestOffset)
-      llvm::dbgs() << "Destination Offset: " << DestSrc.DestOffset << "\n";
+      llvm::dbgs() << "; off:" << DestSrc.DestOffset;
+    llvm::dbgs() << "}\n";
   }
   if (DestSrc.Source) {
-    llvm::dbgs() << "Source1: ";
-    DestSrc.Source->dump();
-    if (DestSrc.SrcOffset)
-      llvm::dbgs() << "Source1 Offset: " << DestSrc.SrcOffset << "\n";
+    llvm::dbgs() << "Src1 {";
+    if (DestSrc.Source->isReg()) {
+      llvm::dbgs() << "reg:" << printReg(DestSrc.Source->getReg(), TRI);
+      if (DestSrc.SrcOffset)
+        llvm::dbgs() << "; off:" << DestSrc.SrcOffset;
+    }
+    if (DestSrc.Source->isImm())
+      llvm::dbgs() << "imm:" << DestSrc.Source->getImm();
+    llvm::dbgs() << "}\n";
   }
   if (DestSrc.Source2) {
-    llvm::dbgs() << "Source2: ";
-    DestSrc.Source->dump();
-    if (DestSrc.Src2Offset)
-      llvm::dbgs() << "Source2 offset: " << DestSrc.Src2Offset << "\n";
-  }
-  if (DestSrc.DestScaledIndex) {
-    llvm::dbgs() << "DestScaledIndex: ";
-    DestSrc.DestScaledIndex->dump();
-    if (DestSrc.DestOffsetReg) {
-      llvm::dbgs() << "DestOffReg: ";
-      DestSrc.DestOffsetReg->dump();
+    llvm::dbgs() << "Src2 {";
+    if (DestSrc.Source2->isReg()) {
+      llvm::dbgs() << "reg:" << printReg(DestSrc.Source2->getReg(), TRI);
+      if (DestSrc.Src2Offset)
+        llvm::dbgs() << "; off:" << DestSrc.Src2Offset;
     }
+    if (DestSrc.Source2->isImm())
+      llvm::dbgs() << "imm:" << DestSrc.Source2->getImm();
+    llvm::dbgs() << "}\n";
   }
-  if (DestSrc.SrcScaledIndex) {
-    llvm::dbgs() << "SrcScaledIndex: ";
-    DestSrc.SrcScaledIndex->dump();
-    if (DestSrc.SrcOffsetReg) {
-      llvm::dbgs() << "SrcOffReg: ";
-      DestSrc.SrcOffsetReg->dump();
-    }
-  }
+  // TODO: Add support for Scaled Index Addressing Mode
 }
 
 MachineFunction* crash_analyzer::TaintAnalysis::getCalledMF(const BlameModule &BM, std::string Name) {

--- a/llvm-10.0.1/llvm-crash-analyzer/lib/Analysis/TaintAnalysis.cpp
+++ b/llvm-10.0.1/llvm-crash-analyzer/lib/Analysis/TaintAnalysis.cpp
@@ -7,15 +7,14 @@
 //===----------------------------------------------------------------------===//
 
 #include "Analysis/TaintAnalysis.h"
-#include "Analysis/RegisterEquivalence.h"
-#include "Decompiler/Decompiler.h"
 #include "Analysis/ConcreteReverseExec.h"
+#include "Analysis/RegisterEquivalence.h"
 #include "Analysis/TaintDataFlowGraph.h"
-
+#include "Decompiler/Decompiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/PostOrderIterator.h"
 #include "llvm/IR/DebugInfoMetadata.h"
-
+#include "llvm/Support/Debug.h"
 #include <sstream>
 
 static constexpr unsigned FrameLevelDepthToGo = 10;
@@ -26,6 +25,11 @@ DumpTaintGraphAsDOT("print-dfg-as-dot",
                      cl::desc("Print Tainted graph for the GraphViz."),
                      cl::value_desc("filename"),
                      cl::init(""));
+
+static cl::opt<bool> PrintDestSrcOperands(
+    "print-dest-src-operands",
+    cl::desc("Print Destination and Source Operands for each MIR"),
+    cl::init(false));
 
 using namespace llvm;
 
@@ -406,24 +410,57 @@ void crash_analyzer::TaintAnalysis::printTaintList2(
   } dbgs() << "\n------Taint List End----\n";
 }
 
-void crash_analyzer::TaintAnalysis::printDestSrcInfo(DestSourcePair &DestSrc) {
-  LLVM_DEBUG(
-      if (DestSrc.Destination) {
-        llvm::dbgs() << "dest: ";
-        DestSrc.Destination->dump();
-        if (DestSrc.DestOffset)
-          llvm::dbgs() << "dest offset: " << DestSrc.DestOffset << "\n";
-      } if (DestSrc.Source) {
-        llvm::dbgs() << "src: ";
-        DestSrc.Source->dump();
-        if (DestSrc.SrcOffset)
-          llvm::dbgs() << "src offset: " << DestSrc.SrcOffset << "\n";
-      } if (DestSrc.Source2) {
-        llvm::dbgs() << "src2: ";
-        DestSrc.Source2->dump();
-        if (DestSrc.Src2Offset)
-          llvm::dbgs() << "src2 offset: " << DestSrc.Src2Offset << "\n";
-      });
+inline static bool isDebug() {
+#ifndef NDEBUG
+  return DebugFlag && isCurrentDebugType(DEBUG_TYPE);
+#else
+  return false;
+#endif
+}
+
+// Print the destination and source operands info if either of the option
+// -print-dest-src-operands or --debug-only=taint-analysis is used.
+void crash_analyzer::TaintAnalysis::printDestSrcInfo(DestSourcePair &DestSrc,
+                                                     const MachineInstr &MI) {
+  if (!PrintDestSrcOperands && !isDebug())
+    return;
+
+  MI.dump();
+
+  if (DestSrc.Destination) {
+    llvm::dbgs() << "Destination: ";
+    DestSrc.Destination->dump();
+    if (DestSrc.DestOffset)
+      llvm::dbgs() << "Destination Offset: " << DestSrc.DestOffset << "\n";
+  }
+  if (DestSrc.Source) {
+    llvm::dbgs() << "Source1: ";
+    DestSrc.Source->dump();
+    if (DestSrc.SrcOffset)
+      llvm::dbgs() << "Source1 Offset: " << DestSrc.SrcOffset << "\n";
+  }
+  if (DestSrc.Source2) {
+    llvm::dbgs() << "Source2: ";
+    DestSrc.Source->dump();
+    if (DestSrc.Src2Offset)
+      llvm::dbgs() << "Source2 offset: " << DestSrc.Src2Offset << "\n";
+  }
+  if (DestSrc.DestScaledIndex) {
+    llvm::dbgs() << "DestScaledIndex: ";
+    DestSrc.DestScaledIndex->dump();
+    if (DestSrc.DestOffsetReg) {
+      llvm::dbgs() << "DestOffReg: ";
+      DestSrc.DestOffsetReg->dump();
+    }
+  }
+  if (DestSrc.SrcScaledIndex) {
+    llvm::dbgs() << "SrcScaledIndex: ";
+    DestSrc.SrcScaledIndex->dump();
+    if (DestSrc.SrcOffsetReg) {
+      llvm::dbgs() << "SrcOffReg: ";
+      DestSrc.SrcOffsetReg->dump();
+    }
+  }
 }
 
 MachineFunction* crash_analyzer::TaintAnalysis::getCalledMF(const BlameModule &BM, std::string Name) {
@@ -841,6 +878,7 @@ bool crash_analyzer::TaintAnalysis::runOnBlameMF(BlameModule &BM,
           mergeTaintList(TL_Mbb, TaintList);
           continue;
         }
+        printDestSrcInfo(*DestSrc, MI);
         startTaint(*DestSrc, TL_Mbb, MI2, TaintDFG, REAnalysis);
         continue;
       }
@@ -902,9 +940,6 @@ bool crash_analyzer::TaintAnalysis::runOnBlameMF(BlameModule &BM,
       if (MI.isBranch())
         continue;
 
-      // Print the instruction from crash-start point
-      LLVM_DEBUG(MI.dump(););
-
       // We reached the end of the frame.
       if (TII->isPush(MI))
         break;
@@ -924,7 +959,7 @@ bool crash_analyzer::TaintAnalysis::runOnBlameMF(BlameModule &BM,
         continue;
       }
 
-      printDestSrcInfo(*DestSrc);
+      printDestSrcInfo(*DestSrc, MI);
 
       // Backward Taint Analysis.
       bool TaintResult = propagateTaint(*DestSrc, TL_Mbb, MI, TaintDFG, REAnalysis,

--- a/llvm-10.0.1/llvm-crash-analyzer/test/Analysis/test-verify-src-dest.mir
+++ b/llvm-10.0.1/llvm-crash-analyzer/test/Analysis/test-verify-src-dest.mir
@@ -1,0 +1,169 @@
+
+# RUN: %llvm-crash-analyzer-ta -print-dest-src-operands %s 2> %t.log
+# RUN: FileCheck %s < %t.log
+# CHECK:   $edx = crash-start MOV32rm $rcx, 1, $noreg, 0, $noreg
+# CHECK: Destination: $edx
+# CHECK: Source1: $rcx
+# CHECK: Source1 Offset: 0
+# CHECK:   ADD64mi8 $rbp, 1, $noreg, 327056915, $noreg, 1, implicit-def $eflags
+# CHECK: Destination: $rbp
+# CHECK: Destination Offset: 327056915
+# CHECK: Source1: 1
+# CHECK:   MOV32mi $rbp, 1, $noreg, -4, $noreg, 0
+# CHECK: Destination: $rbp
+# CHECK: Destination Offset: -4
+# CHECK: Source1: 0
+# CHECK:   TEST8mi $rdx, 1, $noreg, 11, $noreg, 1, implicit-def $eflags
+# CHECK: Source1: $rdx
+# CHECK: Source1 Offset: 11
+# CHECK: Source2: $rdx
+# CHECK:   $eax = XOR32rr undef $eax(tied-def 0), undef $eax, implicit-def $eflags
+# CHECK: Destination: $eax
+# CHECK: Source1: $eax
+# CHECK:   $rbp = MOV64rr $rsp
+# CHECK: Destination: $rbp
+# CHECK: Source1: $rsp
+
+--- |
+  ; ModuleID = 'a.out'
+  source_filename = "a.out"
+  target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+
+  ; Materializable
+  define void @main() {
+  entry:
+    unreachable
+  }
+
+...
+---
+name:            main
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+registers:       []
+liveins:         []
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+callSites:       []
+debugValueSubstitutions: []
+regInfo:         { GPRegs:
+    - { reg: rax, value: '0x0000000000000000' }
+    - { reg: rbx, value: '0x0000000000000000' }
+    - { reg: rcx, value: '0x0000000000000000' }
+    - { reg: rdx, value: '0x00007ffd565bba88' }
+    - { reg: rdi, value: '0x0000000000000001' }
+    - { reg: rsi, value: '0x00007ffd565bba78' }
+    - { reg: rbp, value: '0x00007ffd565bb990' }
+    - { reg: rsp, value: '0x00007ffd565bb990' }
+    - { reg: r8, value: '0x00007f6851f9ed20' }
+    - { reg: r9, value: '0x00007f6851f9ed20' }
+    - { reg: r10, value: '0x0000000000000001' }
+    - { reg: r11, value: '0x0000000000000206' }
+    - { reg: r12, value: '0x0000000000400450' }
+    - { reg: r13, value: '0x00007ffd565bba70' }
+    - { reg: r14, value: '0x0000000000000000' }
+    - { reg: r15, value: '0x0000000000000000' }
+    - { reg: rip, value: '0x0000000000400559' }
+    - { reg: rflags, value: '0x0000000000010246' }
+    - { reg: cs, value: '0x0000000000000033' }
+    - { reg: fs, value: '0x0000000000000000' }
+    - { reg: gs, value: '0x0000000000000000' }
+    - { reg: ss, value: '0x000000000000002b' }
+    - { reg: ds, value: '0x0000000000000000' }
+    - { reg: es, value: '0x0000000000000000' }
+    - { reg: eax, value: '0x00000000' }
+    - { reg: ebx, value: '0x00000000' }
+    - { reg: ecx, value: '0x00000000' }
+    - { reg: edx, value: '0x565bba88' }
+    - { reg: edi, value: '0x00000001' }
+    - { reg: esi, value: '0x565bba78' }
+    - { reg: ebp, value: '0x565bb990' }
+    - { reg: esp, value: '0x565bb990' }
+    - { reg: r8d, value: '0x51f9ed20' }
+    - { reg: r9d, value: '0x51f9ed20' }
+    - { reg: r10d, value: '0x00000001' }
+    - { reg: r11d, value: '0x00000206' }
+    - { reg: r12d, value: '0x00400450' }
+    - { reg: r13d, value: '0x565bba70' }
+    - { reg: r14d, value: '0x00000000' }
+    - { reg: r15d, value: '0x00000000' }
+    - { reg: ax, value: '0x0000' }
+    - { reg: bx, value: '0x0000' }
+    - { reg: cx, value: '0x0000' }
+    - { reg: dx, value: '0xba88' }
+    - { reg: di, value: '0x0001' }
+    - { reg: si, value: '0xba78' }
+    - { reg: bp, value: '0xb990' }
+    - { reg: sp, value: '0xb990' }
+    - { reg: r8w, value: '0xed20' }
+    - { reg: r9w, value: '0xed20' }
+    - { reg: r10w, value: '0x0001' }
+    - { reg: r11w, value: '0x0206' }
+    - { reg: r12w, value: '0x0450' }
+    - { reg: r13w, value: '0xba70' }
+    - { reg: r14w, value: '0x0000' }
+    - { reg: r15w, value: '0x0000' }
+    - { reg: ah, value: '0x00' }
+    - { reg: bh, value: '0x00' }
+    - { reg: ch, value: '0x00' }
+    - { reg: dh, value: '0xba' }
+    - { reg: al, value: '0x00' }
+    - { reg: bl, value: '0x00' }
+    - { reg: cl, value: '0x00' }
+    - { reg: dl, value: '0x88' }
+    - { reg: dil, value: '0x01' }
+    - { reg: sil, value: '0x78' }
+    - { reg: bpl, value: '0x90' }
+    - { reg: spl, value: '0x90' }
+    - { reg: r8l, value: '0x20' }
+    - { reg: r9l, value: '0x20' }
+    - { reg: r10l, value: '0x01' }
+    - { reg: r11l, value: '0x06' }
+    - { reg: r12l, value: '0x50' }
+    - { reg: r13l, value: '0x70' }
+    - { reg: r14l, value: '0x00' }
+    - { reg: r15l, value: '0x00' } }
+constants:       []
+machineFunctionInfo: {}
+crashOrder:      1
+body:             |
+  bb.0:
+    liveins: $rbp, $r14d, $ecx, $rdx, $rdi, $rsi, $ymm0, $rax
+
+    PUSH64r $rbp, implicit-def $rsp, implicit $rsp
+    $rbp = MOV64rr $rsp
+    $eax = XOR32rr undef $eax, undef $eax, implicit-def $eflags
+    TEST8mi $rdx, 1, $noreg, 11, $noreg, 1, implicit-def $eflags
+    MOV32mi $rbp, 1, $noreg, -4, $noreg, 0
+    ADD64mi8 $rbp, 1, $noreg, 327056915, $noreg, 1, implicit-def $eflags
+    $edx = crash-start MOV32rm $rcx, 1, $noreg, 0, $noreg
+    $edx = ADD32ri8 $edx, 2, implicit-def $eflags
+    MOV32mr $rbp, 1, $noreg, -20, $noreg, $edx
+    $rbp = POP64r implicit-def $rsp, implicit $rsp
+    RETQ
+...

--- a/llvm-10.0.1/llvm-crash-analyzer/test/Analysis/test-verify-src-dest.mir
+++ b/llvm-10.0.1/llvm-crash-analyzer/test/Analysis/test-verify-src-dest.mir
@@ -1,29 +1,24 @@
 
 # RUN: %llvm-crash-analyzer-ta -print-dest-src-operands %s 2> %t.log
 # RUN: FileCheck %s < %t.log
-# CHECK:   $edx = crash-start MOV32rm $rcx, 1, $noreg, 0, $noreg
-# CHECK: Destination: $edx
-# CHECK: Source1: $rcx
-# CHECK: Source1 Offset: 0
-# CHECK:   ADD64mi8 $rbp, 1, $noreg, 327056915, $noreg, 1, implicit-def $eflags
-# CHECK: Destination: $rbp
-# CHECK: Destination Offset: 327056915
-# CHECK: Source1: 1
-# CHECK:   MOV32mi $rbp, 1, $noreg, -4, $noreg, 0
-# CHECK: Destination: $rbp
-# CHECK: Destination Offset: -4
-# CHECK: Source1: 0
-# CHECK:   TEST8mi $rdx, 1, $noreg, 11, $noreg, 1, implicit-def $eflags
-# CHECK: Source1: $rdx
-# CHECK: Source1 Offset: 11
-# CHECK: Source2: $rdx
-# CHECK:   $eax = XOR32rr undef $eax(tied-def 0), undef $eax, implicit-def $eflags
-# CHECK: Destination: $eax
-# CHECK: Source1: $eax
-# CHECK:   $rbp = MOV64rr $rsp
-# CHECK: Destination: $rbp
-# CHECK: Source1: $rsp
-
+# CHECK:  $edx = crash-start MOV32rm $rcx, 1, $noreg, 0, $noreg
+# CHECK:Dest {reg:$edx}
+# CHECK:Src1 {reg:$rcx; off:0}
+# CHECK:  ADD64mi8 $rbp, 1, $noreg, 327056915, $noreg, 1, implicit-def $eflags
+# CHECK:Dest {reg:$rbp; off:327056915}
+# CHECK:Src1 {imm:1}
+# CHECK:  MOV32mi $rbp, 1, $noreg, -4, $noreg, 0
+# CHECK:Dest {reg:$rbp; off:-4}
+# CHECK:Src1 {imm:0}
+# CHECK:  TEST8mi $rdx, 1, $noreg, 11, $noreg, 1, implicit-def $eflags
+# CHECK:Src1 {reg:$rdx; off:11}
+# CHECK:Src2 {imm:1}
+# CHECK:  $eax = XOR32rr undef $eax(tied-def 0), undef $eax, implicit-def $eflags
+# CHECK:Dest {reg:$eax}
+# CHECK:Src1 {reg:$eax}
+# CHECK:  $rbp = MOV64rr $rsp
+# CHECK:Dest {reg:$rbp}
+# CHECK:Src1 {reg:$rsp}
 --- |
   ; ModuleID = 'a.out'
   source_filename = "a.out"
@@ -153,7 +148,7 @@ machineFunctionInfo: {}
 crashOrder:      1
 body:             |
   bb.0:
-    liveins: $rbp, $r14d, $ecx, $rdx, $rdi, $rsi, $ymm0, $rax
+    liveins: $rbp, $r14d, $ecx, $rdx, $rdi, $rsi, $rax
 
     PUSH64r $rbp, implicit-def $rsp, implicit $rsp
     $rbp = MOV64rr $rsp

--- a/llvm-10.0.1/llvm/lib/Target/X86/X86InstrInfo.cpp
+++ b/llvm-10.0.1/llvm/lib/Target/X86/X86InstrInfo.cpp
@@ -759,7 +759,16 @@ X86InstrInfo::getDestAndSrc(const MachineInstr &MI) const {
       const MachineOperand *Dest = &(MI.getOperand(0));
       const MachineOperand *Src = &(MI.getOperand(2));
       return DestSourcePair{*Dest, *Src};
-    } case X86::TEST32mi:
+      }
+      case X86::TEST8mi:
+      case X86::TEST16mi:
+      case X86::TEST32mi: {
+        if (!getMemOperandWithOffset(MI, BaseOp, Offset, TRI))
+          return None;
+        return DestSourcePair{
+            nullptr, BaseOp,  None,    Offset, &MI.getOperand(5),
+            None,    nullptr, nullptr, 0};
+      }
       case X86::TEST16i16:
       case X86::TEST16mr:
       case X86::TEST16ri:
@@ -776,7 +785,6 @@ X86InstrInfo::getDestAndSrc(const MachineInstr &MI) const {
       case X86::TEST8mr:
       case X86::TEST8ri:
       case X86::TEST8rr:
-      case X86::TEST8mi:
       case X86::CMP16i16:
       case X86::CMP16mr:
       case X86::CMP16ri:


### PR DESCRIPTION
- Handle TEST[x]mi MIR to identify destination/source operands in MIR
- Implement -print-dest-src-operands to print the dest/source operands. This  comes in handy when writing unit-tests as we add support for more instructions in X86InstrInfo::getDestAndSrc.