### PR TITLE
[TA] New TaintInfo equivalence operator

### DIFF
--- a/llvm-10.0.1/llvm-crash-analyzer/lib/Analysis/TaintAnalysis.cpp
+++ b/llvm-10.0.1/llvm-crash-analyzer/lib/Analysis/TaintAnalysis.cpp
@@ -42,6 +42,10 @@ unsigned Node::NextID = 0;
 // New implementation of operator==.
 bool llvm::crash_analyzer::operator==(const TaintInfo &T1,
                                       const TaintInfo &T2) {
+  // Compare immediate values.
+  if (T1.Op->isImm() && T2.Op->isImm())
+    return T1.Op->getImm() == T2.Op->getImm();
+
   // Both operands needs to be reg operands.
   if (!T1.Op->isReg() || !T2.Op->isReg())
     return false;

--- a/llvm-10.0.1/llvm-crash-analyzer/lib/Analysis/TaintAnalysis.cpp
+++ b/llvm-10.0.1/llvm-crash-analyzer/lib/Analysis/TaintAnalysis.cpp
@@ -39,85 +39,54 @@ using TaintInfo = llvm::crash_analyzer::TaintInfo;
 
 unsigned Node::NextID = 0;
 
-bool llvm::crash_analyzer::operator==(const TaintInfo &T1, const TaintInfo &T2) {
-  const MachineFunction *MF = T1.Op->getParent()->getMF();
-  auto TRI = MF->getSubtarget().getRegisterInfo();
-  auto CATI = getCATargetInfoInstance();
-  if (!T1.IsTaintMemAddr() && !T2.IsTaintMemAddr()) {
-    // Both operands needs to be reg operands
-    if (!T1.Op->isReg() || !T2.Op->isReg())
-      return false;
-
-    if (T1.Op->getReg() == T2.Op->getReg()) {
-      // Check if both operands have an offset
-      if (T1.Offset && T2.Offset) {
-        std::string RegName = TRI->getRegAsmName(T1.Op->getReg()).lower();
-        // Compare offsets only if they point to a stack location
-        if (CATI->isSPRegister(RegName) || CATI->isBPRegister(RegName)) {
-          return *T1.Offset == *T2.Offset;
-        }
-      } else
-        return true;
-    }
-
-    // Check for noreg case.
-    // Check offsets if both operands are noreg
-    if (!T1.Op->getReg() && !T2.Op->getReg()) {
-      if (T1.Offset && T2.Offset)
-        return *T1.Offset == *T2.Offset;
-    }
-
-    if (!T1.Op->getReg() || !T2.Op->getReg())
-      return false;
-
-    // Check if the registers are alias to each other
-    // eax and rax, for example
-    for (MCRegAliasIterator RAI(T1.Op->getReg(), TRI, true); RAI.isValid();
-         ++RAI) {
-      if ((*RAI).id() == T2.Op->getReg()) {
-        return true;
-      }
-    }
-  }
-
-  // For mem taint ops, compare the actual addresses.
-  if (T1.IsTaintMemAddr() && T2.IsTaintMemAddr())
-    // Here we should be comparing addresses if both available only.
-    return T1.GetTaintMemAddr() == T2.GetTaintMemAddr();
-
+// New implementation of operator==.
+bool llvm::crash_analyzer::operator==(const TaintInfo &T1,
+                                      const TaintInfo &T2) {
+  // Both operands needs to be reg operands.
   if (!T1.Op->isReg() || !T2.Op->isReg())
     return false;
 
-  // Here we check mem addr base and reg.
-  // e.g.: $rsp + 0 == $rsp
-  // TODO: Should we check the offset is 0 here?
-  if (T1.Op->getReg() == T2.Op->getReg()) {
-    if (!T1.Offset && T2.Offset) {
-      return *T2.Offset == 0;
+  const MachineFunction *MF = T1.Op->getParent()->getMF();
+  auto TRI = MF->getSubtarget().getRegisterInfo();
+  // Check if register operands match, including $noreg case.
+  bool RegsMatch = T1.Op->getReg() == T2.Op->getReg();
+  // Check if the registers are aliases to each other eax and rax, for example.
+  if (T1.Op->getReg() && T2.Op->getReg()) {
+    for (MCRegAliasIterator RAI(T1.Op->getReg(), TRI, true); RAI.isValid();
+         ++RAI) {
+      if ((*RAI).id() == T2.Op->getReg()) {
+        RegsMatch = true;
+      }
     }
-    if (!T2.Offset && T1.Offset) {
-      return *T1.Offset == 0;
-    }
-    return *T1.Offset == *T2.Offset;
   }
 
-  // $noreg case
-  if (!T1.Op->getReg() || !T2.Op->getReg())
-    return false;
+  // Both are memory locations.
+  if (T1.Offset && T2.Offset) {
+    // Both have ConcreteMemoryAddress calculated.
+    if (T1.IsTaintMemAddr() && T2.IsTaintMemAddr())
+      // Here we compare addresses if both available only.
+      return T1.GetTaintMemAddr() == T2.GetTaintMemAddr();
 
-  // Check for register aliases.
-  for (MCRegAliasIterator RAI(T1.Op->getReg(), TRI, true); RAI.isValid();
-       ++RAI) {
-    if ((*RAI).id() == T2.Op->getReg()) {
-      if (!T1.Offset && T2.Offset) {
-        return *T2.Offset == 0;
-      }
-      if (!T2.Offset && T1.Offset) {
-        return *T1.Offset == 0;
-      }
+    // Consider cases where ConcreteMemoryAddress is not calculated.
+    if (RegsMatch)
+      // Both Regs and Offsets need to match.
       return *T1.Offset == *T2.Offset;
-    }
+
+    return false;
   }
+
+  // Both are simple register locations.
+  if (!T1.Offset && !T2.Offset)
+    // Just regsiters need to match.
+    return RegsMatch;
+
+  // Consider cases where one TaintInfo is memory location and other is
+  // register. If one has offset zero and other doesn't have offset, consider
+  // them the same. ex. rax == rax + 0 or eax = rax + 0
+  uint64_t Off = T1.Offset ? *T1.Offset : *T2.Offset;
+  if (Off == 0)
+    // Just registers need to match.
+    return RegsMatch;
 
   return false;
 }

--- a/llvm-10.0.1/llvm-crash-analyzer/unittests/Analysis/CMakeLists.txt
+++ b/llvm-10.0.1/llvm-crash-analyzer/unittests/Analysis/CMakeLists.txt
@@ -17,6 +17,7 @@ set(LLVM_LINK_COMPONENTS
 add_crash_balmer_unittest(CRASHANALYZERAnalysisTests
   ConcreteReverseExec.cpp
   RegisterEquivalence.cpp
+  TaintInfo.cpp
   DEPENDS
     intrinsics_gen
 )

--- a/llvm-10.0.1/llvm-crash-analyzer/unittests/Analysis/TaintInfo.cpp
+++ b/llvm-10.0.1/llvm-crash-analyzer/unittests/Analysis/TaintInfo.cpp
@@ -1,0 +1,298 @@
+//===- TaintInfo.cpp ------------ Unit test ---------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "Analysis/TaintAnalysis.h"
+
+#include "llvm/CodeGen/MIRParser/MIRParser.h"
+#include "llvm/CodeGen/MachineBasicBlock.h"
+#include "llvm/CodeGen/MachineFunction.h"
+#include "llvm/CodeGen/MachineInstr.h"
+#include "llvm/CodeGen/MachineMemOperand.h"
+#include "llvm/CodeGen/MachineModuleInfo.h"
+#include "llvm/CodeGen/TargetFrameLowering.h"
+#include "llvm/CodeGen/TargetInstrInfo.h"
+#include "llvm/CodeGen/TargetLowering.h"
+#include "llvm/CodeGen/TargetSubtargetInfo.h"
+#include "llvm/IR/DebugInfoMetadata.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/ModuleSlotTracker.h"
+#include "llvm/MC/MCAsmInfo.h"
+#include "llvm/MC/MCSymbol.h"
+#include "llvm/Support/TargetRegistry.h"
+#include "llvm/Support/TargetSelect.h"
+#include "llvm/Target/TargetMachine.h"
+#include "llvm/Target/TargetOptions.h"
+#include "gtest/gtest.h"
+
+using namespace llvm;
+
+namespace {
+
+std::unique_ptr<LLVMTargetMachine> createTargetMachine() {
+  auto TT(Triple::normalize("x86_64-unknown-unknown"));
+  std::string CPU("");
+  std::string FS("");
+
+  LLVMInitializeX86TargetInfo();
+  LLVMInitializeX86Target();
+  LLVMInitializeX86TargetMC();
+
+  std::string Error;
+  const Target *TheTarget = TargetRegistry::lookupTarget(TT, Error);
+  assert(TheTarget);
+
+  return std::unique_ptr<LLVMTargetMachine>(
+      static_cast<LLVMTargetMachine *>(TheTarget->createTargetMachine(
+          TT, CPU, FS, TargetOptions(), None, None, CodeGenOpt::Default)));
+}
+
+std::unique_ptr<Module> parseMIR(LLVMContext &Context,
+                                 std::unique_ptr<MIRParser> &MIR,
+                                 const TargetMachine &TM, StringRef MIRCode,
+                                 const char *FuncName, MachineModuleInfo &MMI) {
+  SMDiagnostic Diagnostic;
+  std::unique_ptr<MemoryBuffer> MBuffer = MemoryBuffer::getMemBuffer(MIRCode);
+  MIR = createMIRParser(std::move(MBuffer), Context);
+  if (!MIR)
+    return nullptr;
+
+  std::unique_ptr<Module> M = MIR->parseIRModule();
+  if (!M)
+    return nullptr;
+
+  M->setDataLayout(TM.createDataLayout());
+
+  if (MIR->parseMachineFunctions(*M, MMI))
+    return nullptr;
+
+  return M;
+}
+
+// This is dummy unit test.
+TEST(TaintInfo, locationEquivalence) {
+  std::unique_ptr<LLVMTargetMachine> TM = createTargetMachine();
+  ASSERT_TRUE(TM);
+
+  StringRef MIRString = R"MIR(
+--- |
+  ; ModuleID = 'bin/struct1-0'
+  source_filename = "bin/struct1-0"
+  target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+  
+  ; Materializable
+  define void @foo() !dbg !2 {
+  entry:
+    unreachable
+  }
+  
+  !llvm.dbg.cu = !{!0}
+  
+  !0 = distinct !DICompileUnit(language: DW_LANG_C, file: !1, producer: "llvm-crash-analyzer", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug)
+  !1 = !DIFile(filename: "/nobackup/bseshadr/llvm-crash-anal/c_test_cases/struct1.c", directory: "/")
+  !2 = distinct !DISubprogram(name: "foo", linkageName: "foo", scope: null, file: !1, line: 1, type: !3, scopeLine: 1, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !4)
+  !3 = !DISubroutineType(types: !4)
+  !4 = !{}
+
+...
+---
+name:            foo
+alignment:       16
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+registers:       []
+liveins:         []
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  maxCallFrameSize: 4294967295
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+callSites:       []
+debugValueSubstitutions: []
+regInfo:         { GPRegs: 
+    - { reg: rax, value: '0x0000000000000000' }
+    - { reg: rbx, value: '0x0000000000000000' }
+    - { reg: rcx, value: '0x000000000000000a' }
+    - { reg: rdx, value: '0x00007ffe9b333dd8' }
+    - { reg: rdi, value: '0x00007ffe9b333cc8' }
+    - { reg: rsi, value: '0x00007ffe9b333dc8' }
+    - { reg: rbp, value: '0x00007ffe9b333cb0' }
+    - { reg: rsp, value: '0x00007ffe9b333cb0' }
+    - { reg: r8, value: '0x00007f822de54da0' }
+    - { reg: r9, value: '0x00007f822de54da0' }
+    - { reg: r10, value: '0x0000000000000000' }
+    - { reg: r11, value: '0x00007f822dc16630' }
+    - { reg: r12, value: '0x00000000004004c0' }
+    - { reg: r13, value: '0x00007ffe9b333dc0' }
+    - { reg: r14, value: '0x0000000000000000' }
+    - { reg: r15, value: '0x0000000000000000' }
+    - { reg: rip, value: '0x00000000004005c6' }
+    - { reg: rflags, value: '0x0000000000010206' }
+    - { reg: cs, value: '0x0000000000000033' }
+    - { reg: fs, value: '0x0000000000000000' }
+    - { reg: gs, value: '0x0000000000000000' }
+    - { reg: ss, value: '0x000000000000002b' }
+    - { reg: ds, value: '0x0000000000000000' }
+    - { reg: es, value: '0x0000000000000000' }
+    - { reg: eax, value: '0x00000000' }
+    - { reg: ebx, value: '0x00000000' }
+    - { reg: ecx, value: '0x0000000a' }
+    - { reg: edx, value: '0x9b333dd8' }
+    - { reg: edi, value: '0x9b333cc8' }
+    - { reg: esi, value: '0x9b333dc8' }
+    - { reg: ebp, value: '0x9b333cb0' }
+    - { reg: esp, value: '0x9b333cb0' }
+    - { reg: r8d, value: '0x2de54da0' }
+    - { reg: r9d, value: '0x2de54da0' }
+    - { reg: r10d, value: '0x00000000' }
+    - { reg: r11d, value: '0x2dc16630' }
+    - { reg: r12d, value: '0x004004c0' }
+    - { reg: r13d, value: '0x9b333dc0' }
+    - { reg: r14d, value: '0x00000000' }
+    - { reg: r15d, value: '0x00000000' }
+    - { reg: ax, value: '0x0000' }
+    - { reg: bx, value: '0x0000' }
+    - { reg: cx, value: '0x000a' }
+    - { reg: dx, value: '0x3dd8' }
+    - { reg: di, value: '0x3cc8' }
+    - { reg: si, value: '0x3dc8' }
+    - { reg: bp, value: '0x3cb0' }
+    - { reg: sp, value: '0x3cb0' }
+    - { reg: r8w, value: '0x4da0' }
+    - { reg: r9w, value: '0x4da0' }
+    - { reg: r10w, value: '0x0000' }
+    - { reg: r11w, value: '0x6630' }
+    - { reg: r12w, value: '0x04c0' }
+    - { reg: r13w, value: '0x3dc0' }
+    - { reg: r14w, value: '0x0000' }
+    - { reg: r15w, value: '0x0000' }
+    - { reg: ah, value: '0x00' }
+    - { reg: bh, value: '0x00' }
+    - { reg: ch, value: '0x00' }
+    - { reg: dh, value: '0x3d' }
+    - { reg: al, value: '0x00' }
+    - { reg: bl, value: '0x00' }
+    - { reg: cl, value: '0x0a' }
+    - { reg: dl, value: '0xd8' }
+    - { reg: dil, value: '0xc8' }
+    - { reg: sil, value: '0xc8' }
+    - { reg: bpl, value: '0xb0' }
+    - { reg: spl, value: '0xb0' }
+    - { reg: r8l, value: '0xa0' }
+    - { reg: r9l, value: '0xa0' }
+    - { reg: r10l, value: '0x00' }
+    - { reg: r11l, value: '0x30' }
+    - { reg: r12l, value: '0xc0' }
+    - { reg: r13l, value: '0xc0' }
+    - { reg: r14l, value: '0x00' }
+    - { reg: r15l, value: '0x00' } }
+constants:       []
+machineFunctionInfo: {}
+crashOrder:     1
+body:             |
+  bb.0:
+    liveins: $rbp, $rdi
+  
+    PUSH64r $rbp, implicit-def $rsp, implicit $rsp, debug-location !DILocation(line: 11, scope: !2)
+    $rbp = MOV64rr $rsp, debug-location !DILocation(line: 11, scope: !2)
+    MOV64mr $rbp, 1, $noreg, -8, $noreg, $rdi, debug-location !DILocation(line: 11, scope: !2)
+    $rax = MOV64rm $rbp, 1, $noreg, -8, $noreg, debug-location !DILocation(line: 12, column: 9, scope: !2)
+    $ecx = MOV32rm $rax, 1, $noreg, 0, $noreg, debug-location !DILocation(line: 12, column: 12, scope: !2)
+    $rax = MOV64rm $rbp, 1, $noreg, -8, $noreg, debug-location !DILocation(line: 12, column: 16, scope: !2)
+    $rax = MOV64rm $rax, 1, $noreg, 8, $noreg, debug-location !DILocation(line: 12, column: 19, scope: !2)
+    $ecx = crash-start ADD32rm $ecx, $rax, 1, $noreg, 0, $noreg, implicit-def $eflags, debug-location !DILocation(line: 12, column: 13, scope: !2)
+    $eax = MOV32rr $ecx, debug-location !DILocation(line: 12, column: 2, scope: !2)
+    $rbp = POP64r implicit-def $rsp, implicit $rsp, debug-location !DILocation(line: 12, column: 2, scope: !2)
+    RETQ debug-location !DILocation(line: 12, column: 2, scope: !2)
+
+...
+)MIR";
+
+  LLVMContext Context;
+  std::unique_ptr<MIRParser> MIR;
+  MachineModuleInfo MMI(TM.get());
+  std::unique_ptr<Module> M =
+      parseMIR(Context, MIR, *TM, MIRString, "instrInterpretation", MMI);
+  ASSERT_TRUE(M);
+
+  Function *F = M->getFunction("foo");
+  auto *MF = MMI.getMachineFunction(*F);
+  ASSERT_TRUE(MF);
+
+  bool CrashSequenceStarted = false;
+
+  auto TRI = MF->getSubtarget().getRegisterInfo();
+  auto TII = MF->getSubtarget().getInstrInfo();
+  ASSERT_TRUE(TRI);
+  ASSERT_TRUE(TII);
+
+  crash_analyzer::TaintAnalysis TA("", false);
+  // Here we simulate backward Taint Analysis, but we are interested in
+  // inspecting Taint Info management only.
+  for (auto MBBIt = MF->rbegin(); MBBIt != MF->rend(); ++MBBIt) {
+    auto &MBB = *MBBIt;
+    for (auto MIIt = MBB.rbegin(); MIIt != MBB.rend(); ++MIIt) {
+      auto &MI = *MIIt;
+      if (MI.getFlag(MachineInstr::CrashStart)) {
+        CrashSequenceStarted = true;
+        continue;
+      }
+      if (!CrashSequenceStarted)
+        continue;
+      if (MI.isBranch())
+        continue;
+      // We reached the end of the frame.
+      if (TII->isPush(MI))
+        break;
+      if (TII->isLoad(MI)) {
+        auto DestSrc = TII->getDestAndSrc(MI);
+        if (!DestSrc)
+          continue;
+        TA.printDestSrcInfo(*DestSrc, MI);
+
+        crash_analyzer::TaintInfo SrcTi, DestTi;
+        SrcTi.Op = DestSrc->Source;
+        SrcTi.Offset = DestSrc->SrcOffset;
+        if (SrcTi.Offset)
+          TA.calculateMemAddr(SrcTi);
+
+        DestTi.Op = DestSrc->Destination;
+        DestTi.Offset = DestSrc->DestOffset;
+        if (DestTi.Offset)
+          TA.calculateMemAddr(DestTi);
+
+        // For MI $rax = MOV64rm $rax, 1, $noreg, 8, $noreg
+        // Confirm that {reg: $rax} is not equal to {reg:$rax; off:8} in the
+        // case where we can't calculate Concrete Memory Address.
+        ASSERT_FALSE(DestTi == SrcTi);
+      }
+    }
+  }
+}
+
+} // namespace


### PR DESCRIPTION
If TaintInfo doesn't have ConcreteMemoryAddress calculated, that doesn't mean it is not
a memory location (in some cases the ConcreteMemoryAddress is not available).
Current implementation of operator== for TaintInfo has a problem to determine which TaintInfo
is a memory address since it relies on existence of ConcreteMemoryAddress.

In the example below, current implementation would just compare the registers,
since both TaintInfos don't have ConcreteMemoryAddress calculated.

```
 $rax = MOV64rm $rax, 1, $noreg, 8, $noreg
     T1: {reg: $rax}
     T2: {reg:$rax; off:8}
```

This is tested in the new unittest added to inspect Taint Info management
during TaintAnalysis. I have a plan to add more cases for TaintInfo equivalence
testing.

New implementation of operator== relies on existence of Offset instead of ConcreteMemoryAddress.
Additionally, it makes code more readable and separates handling of different TaintInfo types 
(memory locations vs registers).