### PR TITLE
[TaintDFG] Reimplement TaintInfo less-than operator

### DIFF
--- a/llvm-10.0.1/llvm-crash-analyzer/include/Analysis/TaintAnalysis.h
+++ b/llvm-10.0.1/llvm-crash-analyzer/include/Analysis/TaintAnalysis.h
@@ -35,6 +35,8 @@ class ConcreteReverseExec;
 namespace llvm {
 namespace crash_analyzer {
 
+enum TaintInfoType { ImmediateVal, RegisterLoc, MemoryLoc };
+
 // Tainted Operands in a Machine Instruction.
 // This is a Reg-Offset pair.
 // TODO: Take into account:
@@ -54,6 +56,7 @@ struct TaintInfo {
   uint64_t GetTaintMemAddr() const {
     return ConcreteMemoryAddress;
   }
+  std::tuple<unsigned,int,int> getTuple() const;
 
   friend bool operator==(const TaintInfo &T1, const TaintInfo &T2);
   friend bool operator!=(const TaintInfo &T1, const TaintInfo &T2);

--- a/llvm-10.0.1/llvm-crash-analyzer/test/Analysis/null-cmp-O0-analysis.test
+++ b/llvm-10.0.1/llvm-crash-analyzer/test/Analysis/null-cmp-O0-analysis.test
@@ -20,3 +20,8 @@
 # RUN:     %S/Inputs/null-cmp-O0 < %s 2>&1 | FileCheck %s
 
 # CHECK: Blame Function is main
+
+## Test printed DFG format.
+# RUN: %llvm-crash-analyzer --print-dfg-as-dot=%t.dot --core-file=%S/Inputs/core.null-cmp-O0 %S/Inputs/null-cmp-O0 < %s
+# RUN: cat %t.dot | FileCheck --check-prefix=CHECK-DFG %s
+# CHECK-DFG-NOT: {{.*}}CONSTANT: {{[0-9]+}}}"  ->

--- a/llvm-10.0.1/llvm-crash-analyzer/test/Analysis/ptr-arith-1.test
+++ b/llvm-10.0.1/llvm-crash-analyzer/test/Analysis/ptr-arith-1.test
@@ -37,3 +37,8 @@
 # RUN:     %S/Inputs/ptr-arith-1 < %s 2>&1 | FileCheck %s
 
 # CHECK: Blame Function is test_cf
+
+## Test printed DFG format.
+# RUN: %llvm-crash-analyzer --print-dfg-as-dot=%t.dot --core-file=%S/Inputs/core.ptr-arith-1 %S/Inputs/ptr-arith-1 < %s
+# RUN: cat %t.dot | FileCheck --check-prefix=CHECK-DFG %s
+# CHECK-DFG-NOT: {{.*}}CONSTANT: {{[0-9]+}}}"  ->

--- a/llvm-10.0.1/llvm-crash-analyzer/test/Analysis/taint-dest-base-reg.test
+++ b/llvm-10.0.1/llvm-crash-analyzer/test/Analysis/taint-dest-base-reg.test
@@ -72,3 +72,8 @@
 # CHECK-DEBUG-NEXT: {reg:$eax}
 # CHECK-DEBUG-NEXT: {reg:$rbp; off:-8} (mem addr: 140734701020776)
 # CHECK-DEBUG-NEXT: ------Taint List End----
+
+## Test printed DFG format.
+# RUN: %llvm-crash-analyzer --print-dfg-as-dot=%t.dot --core-file=%S/Inputs/core.taint-dest-base-reg %S/Inputs/taint-dest-base-reg.out < %s
+# RUN: cat %t.dot | FileCheck --check-prefix=CHECK-DFG %s
+# CHECK-DFG-NOT: {{.*}}CONSTANT: {{[0-9]+}}}"  ->

--- a/llvm-10.0.1/llvm-crash-analyzer/test/Analysis/taint-dest-base-reg.test
+++ b/llvm-10.0.1/llvm-crash-analyzer/test/Analysis/taint-dest-base-reg.test
@@ -73,7 +73,21 @@
 # CHECK-DEBUG-NEXT: {reg:$rbp; off:-8} (mem addr: 140734701020776)
 # CHECK-DEBUG-NEXT: ------Taint List End----
 
-## Test printed DFG format.
-# RUN: %llvm-crash-analyzer --print-dfg-as-dot=%t.dot --core-file=%S/Inputs/core.taint-dest-base-reg %S/Inputs/taint-dest-base-reg.out < %s
-# RUN: cat %t.dot | FileCheck --check-prefix=CHECK-DFG %s
+## Test printed DFG format (MIR representation).
+# RUN: %llvm-crash-analyzer --print-dfg-as-dot=%t1.dot --core-file=%S/Inputs/core.taint-dest-base-reg %S/Inputs/taint-dest-base-reg.out < %s
+# RUN: cat %t1.dot | FileCheck --check-prefix=CHECK-DFG %s
 # CHECK-DFG-NOT: {{.*}}CONSTANT: {{[0-9]+}}}"  ->
+
+## Test printed DFG format (source code lines).
+# RUN: %llvm-crash-analyzer --print-taint-value-flow-as-dot=%t2.dot --core-file=%S/Inputs/core.taint-dest-base-reg %S/Inputs/taint-dest-base-reg.out < %s
+# RUN: cat %t2.dot | FileCheck --check-prefix=CHECK-TAINT-DFG %s
+# CHECK-TAINT-DFG: digraph TaintDataFlowGraph {
+# CHECK-TAINT-DFG-NEXT: crashNode  -> "[[TEST_FILE:[^:]*]]:13:18" [color="red"];
+# CHECK-TAINT-DFG-NEXT: crashNode  -> "[[TEST_FILE]]:13:18" [color="red"];
+# CHECK-TAINT-DFG-NEXT: crashNode  -> "[[TEST_FILE]]:13:18" [color="red"];
+# CHECK-TAINT-DFG-NEXT: "[[TEST_FILE]]:13:18"  -> "[[TEST_FILE]]:13:4";
+# CHECK-TAINT-DFG-NEXT: "[[TEST_FILE]]:13:18"  -> "[[TEST_FILE]]:13:20";
+# CHECK-TAINT-DFG-NEXT: "[[TEST_FILE]]:13:4"  -> "[[TEST_FILE]]:11:0";
+# CHECK-TAINT-DFG-NEXT: "[[TEST_FILE]]:13:20"  -> "[[TEST_FILE]]:12:8" [color="red"];
+# CHECK-TAINT-DFG-NEXT: "[[TEST_FILE]]:11:0"  -> "[[TEST_FILE]]:19:3";
+# CHECK-TAINT-DFG-NEXT: "[[TEST_FILE]]:19:3"  -> "[[TEST_FILE]]:18:13" [color="red"];


### PR DESCRIPTION
We maintain lastTaintedNode map, to keep track of the last Node (Instruction), which tainted the operand.
To construct Taint Data Flow Graph properly, we create an edge between lastTaintedNode and newTaintNode
for that particular operand.

To keep order in used std::map, where key is operand, represented by TaintInfo class, the operator< of TaintInfo is used.
Previous implementation of TaintInfo operand< was responsible for some incorrect graph construction.

Incorrect DFG generated from test/Analysis/taint-dest-base-reg.test.
![old](https://user-images.githubusercontent.com/51359036/180209012-3ccf6834-37e1-480b-b4ee-be713e09c81d.png)
Please, notice that Node, which represents load of the constant value 2, is not represented as terminal.

The new implementation of TaintInfo operand< is based on tuple representation of a TaintInfo object.
Tuple consists of the following fields:
 1. TaintInfoType - ImmediateVal = 0, RegisterLoc = 1, MemoryLoc = 2;
 2. RegisterID - Register ID (from TargetInfo) or -1 for $noreg;
 3. IntegerValue - Value of Immediate or Offset of Memory Location.

Correct DFG generated from test/Analysis/taint-dest-base-reg.test after applying this patch.
![tuple](https://user-images.githubusercontent.com/51359036/180209039-bd4897ce-89a4-4752-b119-55565aab435f.png)

