### PR TITLE
[DFG] Add Node ID to dot DFG prints

### DIFF
--- a/llvm-10.0.1/llvm-crash-analyzer/lib/Analysis/TaintDataFlowGraph.cpp
+++ b/llvm-10.0.1/llvm-crash-analyzer/lib/Analysis/TaintDataFlowGraph.cpp
@@ -312,6 +312,7 @@ void TaintDataFlowGraph::printAsDOT(std::string fileName,
           if (node->MI) {
             MyDotFile << node->MI->getParent()->getParent()->getCrashOrder()
                       << "; ";
+            MyDotFile << node->getID() << "; ";
             node->MI->print(MyDotFile, /*IsStandalone*/ true,
                             /*SkipOpers*/ false, /*SkipDebugLoc*/ true,
                             /*AddNewLine*/ false);
@@ -360,6 +361,7 @@ void TaintDataFlowGraph::printAsDOT(std::string fileName,
           if (adjNode->MI) {
             MyDotFile << adjNode->MI->getParent()->getParent()->getCrashOrder()
                       << "; ";
+            MyDotFile << adjNode->getID() << "; ";
             adjNode->MI->print(MyDotFile, /*IsStandalone*/ true,
                                /*SkipOpers*/ false, /*SkipDebugLoc*/ true,
                                /*AddNewLine*/ false);

--- a/llvm-10.0.1/llvm-crash-analyzer/test/Analysis/struct-field-blame.test
+++ b/llvm-10.0.1/llvm-crash-analyzer/test/Analysis/struct-field-blame.test
@@ -35,3 +35,14 @@
 
 # CHECK: Blame Function is func1
 # CHECK: From File {{.*}}/test.c:14:12
+
+## Test printed DFG format (MIR representation).
+# RUN: %llvm-crash-analyzer --print-dfg-as-dot=%t1.dot --core-file=%S/Inputs/core.taint-dest-base-reg %S/Inputs/taint-dest-base-reg.out < %s
+# RUN: cat %t1.dot | FileCheck --check-prefix=CHECK-DFG %s
+# CHECK-DFG: digraph TaintDataFlowGraph {
+# CHECK-DFG-NEXT: crashNode  ->  "{1; 1; crash-start MOV32mr $rcx, 1, $noreg, 4, $noreg, $eax;  MEM: 4}" [color="red"];
+# CHECK-DFG-NEXT: crashNode  ->  "{1; 2; crash-start MOV32mr $rcx, 1, $noreg, 4, $noreg, $eax;  REG: $rcx}" [color="red"];
+# CHECK-DFG-NEXT: crashNode  ->  "{1; 3; crash-start MOV32mr $rcx, 1, $noreg, 4, $noreg, $eax;  REG: $eax}" [color="red"];
+# CHECK-DFG-NEXT: "{1; 2; crash-start MOV32mr $rcx, 1, $noreg, 4, $noreg, $eax;  REG: $rcx}"  ->  "{1; 4; $rcx = MOV64rm $rbp, 1, $noreg, -8, $noreg;  MEM: 140734701020776}";
+# CHECK-DFG-NEXT: "{1; 3; crash-start MOV32mr $rcx, 1, $noreg, 4, $noreg, $eax;  REG: $eax}"  ->  "{1; 5; $eax = MOV32rm $rbp, 1, $noreg, -12, $noreg;  MEM: 140734701020772}";
+# CHECK-DFG-NEXT: "{1; 4; $rcx = MOV64rm $rbp, 1, $noreg, -8, $noreg;  MEM: 140734701020776}"  ->  "{1; 7; MOV64mr $rbp, 1, $noreg, -8, $noreg, $rdi;  REG: $rdi}";


### PR DESCRIPTION
Include Node ID in Taint Info Data Flow Graph prints in DOT format.
This help DOT converter differ nodes expressed by same (instruction and location) string, 
but corresponding to different program point (different instructions).

Incorrectly printed graph example
![dev](https://user-images.githubusercontent.com/51359036/185606027-e4f7b145-f0eb-4562-80bb-2097585ebcf3.png)

Fixed graph print
![dev2](https://user-images.githubusercontent.com/51359036/185606312-e1e1b1d6-1d1b-4bc3-bb9c-d3a6430af9ba.png)

Please, notice that instructions marked with IDs 4 and 8 in the second graph,
are expressed by the same string ("{1; MOV64mr $rbp, 1, $noreg, -16, $noreg, $rax;  REG: $rax}")
in the first graph.


