### PR TITLE
Add support for TEST64rr, CMP64rm

### DIFF
--- a/llvm-10.0.1/llvm-crash-analyzer/lib/Analysis/TaintAnalysis.cpp
+++ b/llvm-10.0.1/llvm-crash-analyzer/lib/Analysis/TaintAnalysis.cpp
@@ -964,11 +964,11 @@ bool crash_analyzer::TaintAnalysis::runOnBlameMF(BlameModule &BM,
 
       auto DestSrc = TII->getDestAndSrc(MI);
       if (!DestSrc) {
+        MI.dump();
         LLVM_DEBUG(llvm::dbgs()
                        << "haven't found dest && source for the MI\n";);
         bool toContinue = continueAnalysis(MI, TL_Mbb, REAnalysis);
         if (!toContinue) {
-          MI.dump();
           WithColor::error(errs())
               << "MIR not handled; Unable to propagate taint analysis\n";
           abortAnalysis = true;

--- a/llvm-10.0.1/llvm-crash-analyzer/test/Analysis/test-verify-src-dest.mir
+++ b/llvm-10.0.1/llvm-crash-analyzer/test/Analysis/test-verify-src-dest.mir
@@ -13,6 +13,12 @@
 # CHECK:  TEST8mi $rdx, 1, $noreg, 11, $noreg, 1, implicit-def $eflags
 # CHECK:Src1 {reg:$rdx; off:11}
 # CHECK:Src2 {imm:1}
+# CHECK:TEST64rr $rdi, $rdi, implicit-def $eflags
+# CHECK:Src1 {reg:$rdi}
+# CHECK:Src2 {reg:$rdi}
+# CHECK: CMP64rm $rax, $rdi, 1, $noreg, 24, $noreg, implicit-def $eflags
+# CHECK:Src1 {reg:$rax}
+# CHECK:Src2 {reg:$rdi; off:24}
 # CHECK:  $eax = XOR32rr undef $eax(tied-def 0), undef $eax, implicit-def $eflags
 # CHECK:Dest {reg:$eax}
 # CHECK:Src1 {reg:$eax}
@@ -153,6 +159,8 @@ body:             |
     PUSH64r $rbp, implicit-def $rsp, implicit $rsp
     $rbp = MOV64rr $rsp
     $eax = XOR32rr undef $eax, undef $eax, implicit-def $eflags
+    CMP64rm $rax, $rdi, 1, $noreg, 24, $noreg, implicit-def $eflags
+    TEST64rr $rdi, $rdi, implicit-def $eflags
     TEST8mi $rdx, 1, $noreg, 11, $noreg, 1, implicit-def $eflags
     MOV32mi $rbp, 1, $noreg, -4, $noreg, 0
     ADD64mi8 $rbp, 1, $noreg, 327056915, $noreg, 1, implicit-def $eflags

--- a/llvm-10.0.1/llvm/lib/Target/X86/X86InstrInfo.cpp
+++ b/llvm-10.0.1/llvm/lib/Target/X86/X86InstrInfo.cpp
@@ -656,13 +656,16 @@ X86InstrInfo::getDestAndSrc(const MachineInstr &MI) const {
       const MachineOperand *Src = &(MI.getOperand(0));
       const MachineOperand *Source2 = &(MI.getOperand(1));
       return DestSourcePair{nullptr, Src, None, None, Source2, None, nullptr, 0, 0};
-    } case X86::CMP32rm: {
+    }
+    case X86::CMP32rm:
+    case X86::CMP64rm: {
       const MachineOperand *Src = &(MI.getOperand(0));
       if (!getMemOperandWithOffset(MI, BaseOp, Offset, TRI))
         return None;
       return DestSourcePair{nullptr, Src, None, None, BaseOp, Offset, nullptr, 0, 0};
-    } case X86::CMP8mi:
-      case X86::CMP32mi8: {
+    }
+    case X86::CMP8mi:
+    case X86::CMP32mi8: {
       const MachineOperand *Src2 = &(MI.getOperand(5));
       if (!getMemOperandWithOffset(MI, BaseOp, Offset, TRI))
         return None;
@@ -769,22 +772,26 @@ X86InstrInfo::getDestAndSrc(const MachineInstr &MI) const {
             nullptr, BaseOp,  None,    Offset, &MI.getOperand(5),
             None,    nullptr, nullptr, 0};
       }
+      case X86::TEST8rr:
+      case X86::TEST16rr:
+      case X86::TEST32rr:
+      case X86::TEST64rr: {
+        return DestSourcePair{nullptr, &MI.getOperand(0), None,
+                              None,    &MI.getOperand(1), None,
+                              nullptr, nullptr,           0};
+      }
       case X86::TEST16i16:
       case X86::TEST16mr:
       case X86::TEST16ri:
-      case X86::TEST16rr:
       case X86::TEST32i32:
       case X86::TEST32mr:
       case X86::TEST32ri:
-      case X86::TEST32rr:
       case X86::TEST64i32:
       case X86::TEST64mr:
       case X86::TEST64ri32:
-      case X86::TEST64rr:
       case X86::TEST8i8:
       case X86::TEST8mr:
       case X86::TEST8ri:
-      case X86::TEST8rr:
       case X86::CMP16i16:
       case X86::CMP16mr:
       case X86::CMP16ri:
@@ -802,7 +809,6 @@ X86InstrInfo::getDestAndSrc(const MachineInstr &MI) const {
       case X86::CMP64mr:
       case X86::CMP64ri32:
       case X86::CMP64ri8:
-      case X86::CMP64rm:
       case X86::CMP64rr:
       case X86::CMP64rr_REV:
       case X86::CMP64mi8:
@@ -872,6 +878,7 @@ X86InstrInfo::getDestAndSrc(const MachineInstr &MI) const {
       // TODO: for DIV -- within operand(2) is the remainder.
       return DestSourcePair{*Dest, *Src};
       }
+      case X86::POP64r:
       case X86::PUSH64r: {
         /* FIXME: This needs to be handled appropriately. Setting destination
            as empty enables the propagation of taint analysis. */


### PR DESCRIPTION
- Add support for some MIR (TESTXXrr, CMP64rm).
- Ignore POP64r instructions for now.
- Print the MI whenever an instruction is not handled. 