### PR TITLE
[RegEq] Invalidate sub/super registers as well

### DIFF
--- a/llvm-10.0.1/llvm-crash-analyzer/include/Analysis/RegisterEquivalence.h
+++ b/llvm-10.0.1/llvm-crash-analyzer/include/Analysis/RegisterEquivalence.h
@@ -83,6 +83,9 @@ public:
   void invalidateRegEq(MachineInstr &MI,
                        RegisterOffsetPair Reg);
 
+  void invalidateAllRegUses(MachineInstr &MI,
+                            RegisterOffsetPair Reg);
+
   void setRegEq(MachineInstr &MI, RegisterOffsetPair Src,
                 RegisterOffsetPair Dest);
 
@@ -101,6 +104,10 @@ public:
   // all regs equivalent to Reg2.
   bool verifyEquivalenceTransitivity(MachineInstr &MI, RegisterOffsetPair Reg1,
                                      RegisterOffsetPair Reg2);
+
+  // If Register is redefined and its equivalances are invalidated,
+  // confirm that that is done for all sub/super registers as well.
+  bool verifyOverlapsInvalidation(MachineInstr &MI, unsigned RegNum);
 
   void join(MachineBasicBlock &MBB, RegisterEqSet &LiveIns);
   void registerEqDFAnalysis(MachineFunction &MF);


### PR DESCRIPTION
When a register is redefined by an instruction, we should invalidate all
equivalences where that register is used:
1. Uses of that particular register (ex. `$eax`) as a simple register location
2. Uses of that register as a base register of dereferenced address (ex. `deref->$eax+(-16)`)
3. Uses of its sub/super registers as a simple register  location (ex. `$rax`, `$ax`...)
4. Uses of its sub/super registers as a base register of dereferenced address (ex. `deref->$rax+(-8)`)

This patch introduces function `RegisterEquivalence::invalidateAllRegUses` as a wrapper of
`RegisterEquivalence::invalidateRegEq`, to address all of the mentioned equivalence invalidations.


```
$rax : { deref->$rbp+(-24) $rax }
deref->$rbp+(-24) : { deref->$rbp+(-24) $rax }

Reg Eq Table after: $eax = MOV32ri 111111

$rax : { deref->$rbp+(-24) $rax }
$eax : { $eax }
deref->$rbp+(-24) : { deref->$rbp+(-24) $rax }
```

In the example above, please notice that after `$eax = MOV32ri 111111`,
redefinition `$eax` should trigger invalidation of `$rax` equivalences,
which is not done, without this patch.