### PR TITLE
[RegEq] Handle Load with same Dest and SrcBase Reg

### DIFF
--- a/llvm-10.0.1/llvm-crash-analyzer/lib/Analysis/RegisterEquivalence.cpp
+++ b/llvm-10.0.1/llvm-crash-analyzer/lib/Analysis/RegisterEquivalence.cpp
@@ -213,6 +213,13 @@ bool RegisterEquivalence::applyLoad(MachineInstr &MI) {
   // First invalidate dest reg, since it is being rewritten.
   invalidateAllRegUses(MI, Dest);
 
+  // If SrcReg is redefined (same as DestReg), set only identity equivalence.
+  if (Src.RegNum == Dest.RegNum) {
+    if (RegInfo[&MI][Dest].find(Src) == RegInfo[&MI][Dest].end())
+      RegInfo[&MI][Src].insert(Src);
+    return true;
+  }
+
   // Set (transitive) equivalence.
   setRegEq(MI, Src, Dest);
   //dumpRegTableAfterMI(&MI);


### PR DESCRIPTION
Please, consider case where Load instruction has the same register as a Destination and a Source Base, like in the example below.

`$rax = MOV64rm $rax, 1, $noreg, -8,`

Currently, after such instruction, we are setting equivalence relation between `$rax` and `deref->$rax+(-8)`.
This is not valid, because Source operand uses old value of `$rax` and Destination operand represents a 
new (redefined) value of `$rax`.

This patch handles such cases by only setting identity equivalence `$rax` == `$rax`, without
considering it equal to the Source operand.