### PR TITLE
[DFG] Fix MEM nodes without Concrete Address

### DIFF
--- a/llvm-10.0.1/llvm-crash-analyzer/include/Analysis/TaintDataFlowGraph.h
+++ b/llvm-10.0.1/llvm-crash-analyzer/include/Analysis/TaintDataFlowGraph.h
@@ -65,6 +65,11 @@ struct Node {
         } else if (TaintOp.IsConcreteMemory) {
           llvm::dbgs() << "MEM: ";
           llvm::dbgs() << TaintOp.GetTaintMemAddr();
+        } else if (TaintOp.Offset) {
+          llvm::dbgs() << "MEM: ";
+          llvm::dbgs() << *TaintOp.Op;
+          llvm::dbgs() << " + ";
+          llvm::dbgs() << *TaintOp.Offset;
         } else {
           llvm::dbgs() << "REG: ";
           llvm::dbgs() << *TaintOp.Op;

--- a/llvm-10.0.1/llvm-crash-analyzer/lib/Analysis/TaintDataFlowGraph.cpp
+++ b/llvm-10.0.1/llvm-crash-analyzer/lib/Analysis/TaintDataFlowGraph.cpp
@@ -328,6 +328,11 @@ void TaintDataFlowGraph::printAsDOT(std::string fileName,
             } else if (node->TaintOp.IsConcreteMemory) {
               MyDotFile << "MEM: ";
               MyDotFile << node->TaintOp.GetTaintMemAddr();
+            } else if (node->TaintOp.Offset) {
+              MyDotFile << "MEM: ";
+              MyDotFile << *node->TaintOp.Op;
+              MyDotFile << " + ";
+              MyDotFile << *node->TaintOp.Offset;
             } else {
               MyDotFile << "REG: ";
               MyDotFile << *(node->TaintOp.Op);
@@ -377,6 +382,11 @@ void TaintDataFlowGraph::printAsDOT(std::string fileName,
             } else if (adjNode->TaintOp.IsConcreteMemory) {
               MyDotFile << "MEM: ";
               MyDotFile << adjNode->TaintOp.GetTaintMemAddr();
+            } else if (adjNode->TaintOp.Offset) {
+              MyDotFile << "MEM: ";
+              MyDotFile << *adjNode->TaintOp.Op;
+              MyDotFile << " + ";
+              MyDotFile << *adjNode->TaintOp.Offset;
             } else {
               MyDotFile << "REG: ";
               MyDotFile << *(adjNode->TaintOp.Op);

--- a/llvm-10.0.1/llvm-crash-analyzer/test/Analysis/struct1-0.mir
+++ b/llvm-10.0.1/llvm-crash-analyzer/test/Analysis/struct1-0.mir
@@ -24,6 +24,11 @@
 # RUN: %llvm-crash-analyzer-ta %s | FileCheck %s
 # CHECK: Blame Function is main
 
+## Verify print of Node which represents Memory Location,
+## but without Concrete Memory Address.
+# RUN: %llvm-crash-analyzer-ta %s --debug-only=taint-dfg 2>&1 | FileCheck %s --check-prefix=CHECK-DFG
+# CHECK-DFG: ***> !2{1; $rax = MOV64rm $rax, 1, $noreg, 8, $noreg; MEM: $rax + 8}
+# CHECK-DFG-NOT: ***> !2{1; $rax = MOV64rm $rax, 1, $noreg, 8, $noreg; REG: $rax}
 --- |
   ; ModuleID = 'bin/struct1-0'
   source_filename = "bin/struct1-0"


### PR DESCRIPTION
In the Taint Data Flow Graph, if node represents Memory Location Taint Info,
and the Concrete Memory Address is not available, print symbolic address
as register + offset, like in the example below.
`!2{1; $rdi = MOV64rm $rax, 1, $noreg, 8, $noreg; MEM: $rax + 8}`

Before this patch, Memory Locations without Concrete Address, were represented
only by the base register (as a simple register location) like in the second example.
`!2{1; $rdi = MOV64rm $rax, 1, $noreg, 8, $noreg; REG: $rax}`