### PR TITLE
[TA] Fix calculateMemAddr for PC relative addresses

### DIFF
--- a/llvm-15.0.3/llvm-crash-analyzer/include/Target/CATargetInfo.h
+++ b/llvm-15.0.3/llvm-crash-analyzer/include/Target/CATargetInfo.h
@@ -39,7 +39,7 @@ protected:
   std::unordered_map<unsigned, RegAliasTuple> RegMap;
 
   // Save PC value for each instruction.
-  std::unordered_map<const MachineInstr*, uint64_t> InstAddrs;
+  std::unordered_map<const MachineInstr*, std::pair<uint64_t,uint64_t>> InstAddrs;
 
   // Singleton class for the CATargetInfo instance.
   template <typename T> class Singleton {
@@ -67,12 +67,17 @@ public:
 
   // Get InstAddr from the InstAddrs map for the MI.
   uint64_t getInstAddr(const MachineInstr* MI) {
-    return InstAddrs[MI];
+    return InstAddrs[MI].first;
+  }
+
+  // Get InstAddr from the InstAddrs map for the MI.
+  uint64_t getInstSize(const MachineInstr* MI) {
+    return InstAddrs[MI].second;
   }
 
   // Set InstAddr in the InstAddrs map for the MI.
-  void setInstAddr(const MachineInstr* MI, uint64_t InstAddr) {
-    InstAddrs[MI] = InstAddr;
+  void setInstAddr(const MachineInstr* MI, uint64_t InstAddr, uint64_t InstSize = 0) {
+    InstAddrs[MI] = {InstAddr, InstSize};
   }
 
   // Return true if the register is used for function return value.

--- a/llvm-15.0.3/llvm-crash-analyzer/lib/Decompiler/Decompiler.cpp
+++ b/llvm-15.0.3/llvm-crash-analyzer/lib/Decompiler/Decompiler.cpp
@@ -358,7 +358,8 @@ bool crash_analyzer::Decompiler::DecodeIntrsToMIR(
       // x86 doesn't support MI size getter. For x86, instructions with the
       // same Opcode could have different sizes.
       // TODO: Add support in X86InstrInfo to make this more efficient.
-      CATI->setInstAddr(MI, Addr.Address, InstSize);
+      if (!CrashStartSet)
+        CATI->setInstAddr(MI, Addr.Address, InstSize);
 
       if (MI->getFlag(MachineInstr::CrashStart))
 	CrashStartSet = true;

--- a/llvm-15.0.3/llvm-crash-analyzer/lib/Decompiler/Decompiler.cpp
+++ b/llvm-15.0.3/llvm-crash-analyzer/lib/Decompiler/Decompiler.cpp
@@ -352,7 +352,7 @@ bool crash_analyzer::Decompiler::DecodeIntrsToMIR(
         MI = addInstr(MF, MBB, Inst, &Loc, CrashStartAddr == Addr.Address,
                       DefinedRegs, FuncStartSymbols, Target);
 
-      assert (MI && "Failed to add the instruction ...");
+      assert(MI && "Failed to add the instruction ...");
 
       // We maintain mapping between MI and its PC address, since TII for
       // x86 doesn't support MI size getter. For x86, instructions with the
@@ -362,30 +362,30 @@ bool crash_analyzer::Decompiler::DecodeIntrsToMIR(
         CATI->setInstAddr(MI, Addr.Address, InstSize);
 
       if (MI->getFlag(MachineInstr::CrashStart))
-	CrashStartSet = true;
+        CrashStartSet = true;
       // There could be multiple branches targeting the same
       // MBB.
       while (BranchesToUpdate.count(Addr.Address)) {
-	auto BranchIt = BranchesToUpdate.find(Addr.Address);
-	MachineInstr *BranchInstr = BranchIt->second;
-	// In the first shot it was an imm representing the address.
-	// Now we set the real MBB as an operand.
-	// FIXME: Should call RemoveOperand(0) and then set it to
-	// the MBB.
-	BranchInstr->getOperand(0) = MachineOperand::CreateMBB(MBB);
-	if (!BranchInstr->getParent()->isSuccessor(MBB))
-	  BranchInstr->getParent()->addSuccessor(MBB);
-	BranchesToUpdate.erase(BranchIt);
+        auto BranchIt = BranchesToUpdate.find(Addr.Address);
+        MachineInstr *BranchInstr = BranchIt->second;
+        // In the first shot it was an imm representing the address.
+        // Now we set the real MBB as an operand.
+        // FIXME: Should call RemoveOperand(0) and then set it to
+        // the MBB.
+        BranchInstr->getOperand(0) = MachineOperand::CreateMBB(MBB);
+        if (!BranchInstr->getParent()->isSuccessor(MBB))
+          BranchInstr->getParent()->addSuccessor(MBB);
+        BranchesToUpdate.erase(BranchIt);
       }
 
       // If the last decompiled instruction is a Call, check if it is the
       // crash-start for this function.
       if (k + 1 == numInstr && !CrashStartSet && MI->isCall()) {
-	auto NoopInst = addNoop(MF, MBB, &Loc);
-	if (NoopInst && CrashStartAddr == Addr.Address + InstSize) {
-	  NoopInst->setFlag(MachineInstr::CrashStart);
-	  CrashStartSet = true;
-	}
+        auto NoopInst = addNoop(MF, MBB, &Loc);
+        if (NoopInst && CrashStartAddr == Addr.Address + InstSize) {
+          NoopInst->setFlag(MachineInstr::CrashStart);
+          CrashStartSet = true;
+        }
       }
     }
 

--- a/llvm-15.0.3/llvm-crash-analyzer/lib/Decompiler/Decompiler.cpp
+++ b/llvm-15.0.3/llvm-crash-analyzer/lib/Decompiler/Decompiler.cpp
@@ -358,7 +358,7 @@ bool crash_analyzer::Decompiler::DecodeIntrsToMIR(
       // x86 doesn't support MI size getter. For x86, instructions with the
       // same Opcode could have different sizes.
       // TODO: Add support in X86InstrInfo to make this more efficient.
-      CATI->setInstAddr(MI, Addr.Address);
+      CATI->setInstAddr(MI, Addr.Address, InstSize);
 
       if (MI->getFlag(MachineInstr::CrashStart))
 	CrashStartSet = true;

--- a/llvm-15.0.3/llvm-crash-analyzer/test/Analysis/rip-value-update.test
+++ b/llvm-15.0.3/llvm-crash-analyzer/test/Analysis/rip-value-update.test
@@ -21,10 +21,10 @@
 ## different program points.
 # RUN: %llvm-crash-analyzer --core-file=%S/Inputs/core.rip-value-update \
 # RUN:   %S/Inputs/rip-value-update.out -debug-only=taint-analysis < %s 2>&1 | FileCheck %s
-# CHECK: Add to TL: {reg:$rip; off:2099629} (mem addr: 6295513)
+# CHECK: Add to TL: {reg:$rip; off:2099629} (mem addr: 6295520)
 
 # RUN: %llvm-crash-analyzer --core-file=%S/Inputs/core.rip-value-update \
 # RUN:   %S/Inputs/rip-value-update.out -debug-only=taint-analysis \
 # RUN:   -start-crash-order=2 -start-taint-reg=rax < %s 2>&1 | FileCheck %s --check-prefix=CHECK2
 
-# CHECK2: Add to TL: {reg:$rip; off:2099594} (mem addr: 6295513)
+# CHECK2: Add to TL: {reg:$rip; off:2099594} (mem addr: 6295520)


### PR DESCRIPTION
Calculate Concrete Memory Address for PC relative addressing mode.
Use PC register value at the next instruction program point as a base register.
Compute next instruction PC value as current PC value plus an instruction size.

```
0x40059f: (size: 11) :   MOV64mi32 $rip, 1, $noreg, 2099886, $noreg, 6295616,
0x4005aa: (size: 3) :   $eax = MOV32rm $rbp, 1, $noreg, -4, $noreg,
````

In the example above, operand `$rip + 2099886`, corresponds to the address `0x40059f + 11 + 2099886`.