### PR TITLE
[TA] Improved global variables support

### DIFF
--- a/llvm-15.0.3/llvm-crash-analyzer/include/Analysis/RegisterEquivalence.h
+++ b/llvm-15.0.3/llvm-crash-analyzer/include/Analysis/RegisterEquivalence.h
@@ -10,6 +10,7 @@
 #define REGISTER_EQ_H
 
 #include "Analysis/TaintAnalysis.h"
+#include "Target/CATargetInfo.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/CodeGen/MachineBasicBlock.h"
 #include "llvm/CodeGen/MachineFunction.h"

--- a/llvm-15.0.3/llvm-crash-analyzer/include/Analysis/TaintAnalysis.h
+++ b/llvm-15.0.3/llvm-crash-analyzer/include/Analysis/TaintAnalysis.h
@@ -57,6 +57,8 @@ struct TaintInfo {
   int DerefLevel = 0;
   void propagateDerefLevel(const MachineInstr& MI);
 
+  bool IsGlobal = false;
+
   friend bool operator==(const TaintInfo &T1, const TaintInfo &T2);
   friend bool operator!=(const TaintInfo &T1, const TaintInfo &T2);
   friend bool operator<(const TaintInfo &T1, const TaintInfo &T2);

--- a/llvm-15.0.3/llvm-crash-analyzer/include/Decompiler/Decompiler.h
+++ b/llvm-15.0.3/llvm-crash-analyzer/include/Decompiler/Decompiler.h
@@ -80,7 +80,6 @@ class Decompiler {
   SmallVector<long, 8> FunctionsThatAreNotInBT;
 
   lldb::SBTarget *DecTarget = nullptr;
-  lldb::SBModule *DecModule = nullptr;
 
   // Store debug info compile units for coresponding files.
   std::unordered_map<std::string, std::pair<DIFile *, DICompileUnit *>> CUs;
@@ -148,9 +147,6 @@ public:
 
   void setTarget(lldb::SBTarget *T) { DecTarget = T; }
   lldb::SBTarget *getTarget() { return DecTarget; }
-
-  void setSBModule(lldb::SBModule *M) { DecModule = M; }
-  lldb::SBModule *getSBModule() { return DecModule; }
 
   class Module &getModule() {
     return *Module.get();

--- a/llvm-15.0.3/llvm-crash-analyzer/include/Target/CATargetInfo.h
+++ b/llvm-15.0.3/llvm-crash-analyzer/include/Target/CATargetInfo.h
@@ -66,12 +66,16 @@ public:
   }
 
   // Get InstAddr from the InstAddrs map for the MI.
-  uint64_t getInstAddr(const MachineInstr* MI) {
+  Optional<uint64_t> getInstAddr(const MachineInstr* MI) {
+    if (InstAddrs.count(MI) == 0)
+      return None;
     return InstAddrs[MI].first;
   }
 
   // Get InstAddr from the InstAddrs map for the MI.
-  uint64_t getInstSize(const MachineInstr* MI) {
+  Optional<uint64_t> getInstSize(const MachineInstr* MI) {
+    if (InstAddrs.count(MI) == 0)
+      return None;
     return InstAddrs[MI].second;
   }
 

--- a/llvm-15.0.3/llvm-crash-analyzer/lib/Analysis/ConcreteReverseExec.cpp
+++ b/llvm-15.0.3/llvm-crash-analyzer/lib/Analysis/ConcreteReverseExec.cpp
@@ -183,9 +183,13 @@ void ConcreteReverseExec::updatePC(const MachineInstr &MI) {
     return;
   std::string RegName = *CATI->getPC();
 
+  if (!CATI->getInstAddr(&MI)) {
+    invalidateRegVal(RegName);
+    return;
+  }
   uint64_t Val = 0;
   // Get MIs PC value saved during decompilation.
-  Val = CATI->getInstAddr(&MI);
+  Val = *CATI->getInstAddr(&MI);
 
   // Write current value of the register in the map.
   writeUIntRegVal(RegName, Val);

--- a/llvm-15.0.3/llvm-crash-analyzer/lib/Analysis/RegisterEquivalence.cpp
+++ b/llvm-15.0.3/llvm-crash-analyzer/lib/Analysis/RegisterEquivalence.cpp
@@ -207,9 +207,9 @@ bool RegisterEquivalence::applyLoad(MachineInstr &MI) {
   // Transform deref->$rip+(off) to deref->$noreg+(rip+off).
   auto CATI = getCATargetInfoInstance();
   std::string RegName = TRI->getRegAsmName(SrcReg).lower();
-  if (CATI->isPCRegister(RegName)) {
+  if (CATI->isPCRegister(RegName) && CATI->getInstAddr(&MI)) {
     SrcReg = 0;
-    SrcOffset += CATI->getInstAddr(&MI) + CATI->getInstSize(&MI);
+    SrcOffset += *CATI->getInstAddr(&MI) + *CATI->getInstSize(&MI);
   }
 
   RegisterOffsetPair Src{SrcReg, SrcOffset};
@@ -251,9 +251,9 @@ bool RegisterEquivalence::applyStore(MachineInstr &MI) {
   // Transform deref->$rip+(off) to deref->$noreg+(rip+off).
   auto CATI = getCATargetInfoInstance();
   std::string RegName = TRI->getRegAsmName(DestReg).lower();
-  if (CATI->isPCRegister(RegName)) {
+  if (CATI->isPCRegister(RegName) && CATI->getInstAddr(&MI)) {
     DestReg = 0;
-    DstOffset += CATI->getInstAddr(&MI) + CATI->getInstSize(&MI);
+    DstOffset += *CATI->getInstAddr(&MI) + *CATI->getInstSize(&MI);
   }
 
   RegisterOffsetPair Dest{DestReg, DstOffset};

--- a/llvm-15.0.3/llvm-crash-analyzer/lib/Analysis/TaintAnalysis.cpp
+++ b/llvm-15.0.3/llvm-crash-analyzer/lib/Analysis/TaintAnalysis.cpp
@@ -287,8 +287,11 @@ void crash_analyzer::TaintAnalysis::calculateMemAddr(TaintInfo &Ti) {
           std::istringstream converter(rValue);
           converter >> std::hex >> AddrValue;
           // If the base register is PC, use address (PC value) of the next MI.
-          if (CATI->isPCRegister(RegName))
-            AddrValue = CATI->getInstAddr(MI) + CATI->getInstSize(MI);
+          if (CATI->isPCRegister(RegName)) {
+            if (!CATI->getInstAddr(MI))
+              continue;
+            AddrValue = *CATI->getInstAddr(MI) + *CATI->getInstSize(MI);
+          }
           Val = AddrValue;
         }
         // If eqR is register location just add the offset to it, if it is a
@@ -319,11 +322,11 @@ void crash_analyzer::TaintAnalysis::calculateMemAddr(TaintInfo &Ti) {
   SS >> RealAddr;
   // If the base register is PC, use address (PC value) of the next MI.
   if (CATI->isPCRegister(RegName)) {
-    if (!MI) {
+    if (!MI || !CATI->getInstAddr(MI)) {
       Ti.IsConcreteMemory = false;
       return;
     }
-    RealAddr = CATI->getInstAddr(MI) + CATI->getInstSize(MI);
+    RealAddr = *CATI->getInstAddr(MI) + *CATI->getInstSize(MI);
   }
 
   // Apply the offset.

--- a/llvm-15.0.3/llvm-crash-analyzer/lib/Analysis/TaintAnalysis.cpp
+++ b/llvm-15.0.3/llvm-crash-analyzer/lib/Analysis/TaintAnalysis.cpp
@@ -415,7 +415,7 @@ bool crash_analyzer::TaintAnalysis::shouldAnalyzeCall(
     if (CATI->isRetValRegister(RegName))
       return true;
     // If a global variable is tainted also return true.
-    // (If operand is noreg and non-zero offset).
+    // FIXME: Should we check for IsGlobal flag.
     if (!Op->getReg() && itr->Offset)
       return true;
   }
@@ -612,14 +612,10 @@ void crash_analyzer::TaintAnalysis::insertTaint(
 
 // Check if Ti represents a global variable and convert Ti into expected form.
 // Expected form is $noreg plus offset, which is the global variable symbol
-// address.
+// address or the Global Offset Table entry.
 bool crash_analyzer::TaintAnalysis::handleGlobalVar(TaintInfo &Ti) {
 
-  if (!Dec)
-    return false;
-
-  auto LLDBModule = Dec->getSBModule();
-  if (!LLDBModule)
+  if (!Dec || !Dec->getTarget())
     return false;
 
   if (!Ti.Op)
@@ -629,6 +625,19 @@ bool crash_analyzer::TaintAnalysis::handleGlobalVar(TaintInfo &Ti) {
   // Get symbol address from Ti ({reg:$noreg; off:ADDR}).
   if (Ti.Op->isReg() && Ti.Op->getReg() == 0 && Ti.Offset)
     ImmVal = *Ti.Offset;
+
+  bool Indirect = false;
+  if (Ti.Op->isReg()) {
+    auto CATI = getCATargetInfoInstance();
+    const MachineFunction *MF = Ti.Op->getParent()->getMF();
+    auto TRI = MF->getSubtarget().getRegisterInfo();
+    std::string RegName = TRI->getRegAsmName(Ti.Op->getReg()).lower();
+    // Get Global Offset Table entry address for Ti ({reg:$rip; off:GOT_ADDR}).
+    if (CATI->isPCRegister(RegName) && Ti.Offset && Ti.IsTaintMemAddr()) {
+      ImmVal = Ti.ConcreteMemoryAddress;
+      Indirect = true;
+    }
+  }
 
   // Get symbol address from Ti ({imm:ADDR}).
   if (Ti.Op->isImm())
@@ -641,28 +650,45 @@ bool crash_analyzer::TaintAnalysis::handleGlobalVar(TaintInfo &Ti) {
     return false;
 
   uint64_t VarAddr = static_cast<uint64_t>(*ImmVal);
+  // Read global symbol address from Global Offset Table.
+  if (Indirect) {
+    lldb::SBError err;
+    VarAddr = Dec->getTarget()->GetProcess().ReadUnsignedFromMemory(
+        static_cast<uint64_t>(VarAddr), 8, err);
+  }
 
-  // Search symbols for global var with the matching address.
-  int NumSym = static_cast<int>(LLDBModule->GetNumSymbols());
-  for (int i = 0; i < NumSym; i++) {
-    auto SBSym = LLDBModule->GetSymbolAtIndex(i);
-    auto SymAddr = SBSym.GetStartAddress().GetLoadAddress(*Dec->getTarget());
-    // Check symbol address and if it is a global variable.
-    if (SymAddr == VarAddr &&
-        Dec->getTarget()->FindFirstGlobalVariable(SBSym.GetName())) {
-      LLVM_DEBUG(dbgs() << "Handle global variable \"" << SBSym.GetName()
-                        << "\"\n");
-      // Convert Ti from {imm:ADDR} to {reg:$noreg; off:ADDR}.
-      if (Ti.Op->isImm()) {
-        Ti.Offset = VarAddr;
-        MachineOperand *MO2 = new MachineOperand(*Ti.Op);
-        MO2->ChangeToRegister(0, false);
-        Ti.Op = MO2;
-        LLVM_DEBUG(dbgs() << "Update Taint Info to " << Ti << "\n");
+  auto SBTarget = Dec->getTarget();
+  // Construct SBAddress for simbol from GOT.
+  lldb::SBAddress SBAddr;
+  SBAddr.SetLoadAddress((lldb::addr_t)VarAddr, *SBTarget);
+
+  // Search symbols in each module for global var with the matching address.
+  for (uint32_t Mods = 0; Mods < SBTarget->GetNumModules(); ++Mods) {
+    auto SBModule = SBTarget->GetModuleAtIndex(Mods);
+    if (SBModule.GetNumCompileUnits() != 1)
+      continue;
+    int NumSym = static_cast<int>(SBModule.GetNumSymbols());
+    for (int i = 0; i < NumSym; i++) {
+      auto SBSym = SBModule.GetSymbolAtIndex(i);
+      auto SymAddr = SBSym.GetStartAddress().GetLoadAddress(*SBTarget);
+      // Check if it is external symbol with the matching load address.
+      if (SBSym.IsExternal() && SymAddr == SBAddr.GetLoadAddress(*SBTarget)) {
+        // Convert Ti from {imm:ADDR} to {reg:$noreg; off:ADDR}
+        // and ({reg:$rip; off:GOT_ADDR}) to {reg:$noreg; off:GOT_ADDR}
+        if (Ti.Op->isImm() || Indirect) {
+          Ti.Offset = static_cast<uint64_t>(*ImmVal);
+          MachineOperand *MO2 = new MachineOperand(*Ti.Op);
+          MO2->ChangeToRegister(0, false);
+          Ti.Op = MO2;
+          calculateMemAddr(Ti);
+          LLVM_DEBUG(dbgs() << "Update Global Var Taint Info to " << Ti << "\n");
+        }
+        Ti.IsGlobal = true;
+        return true;
       }
-      return true;
     }
   }
+
   return false;
 }
 
@@ -678,6 +704,7 @@ void crash_analyzer::TaintAnalysis::startTaint(
   SrcTi.Offset = DS.SrcOffset;
   if (SrcTi.Offset)
     calculateMemAddr(SrcTi);
+  handleGlobalVar(SrcTi);
 
   SrcScaleReg.Op = DS.SrcScaledIndex;
 
@@ -685,6 +712,7 @@ void crash_analyzer::TaintAnalysis::startTaint(
   DestTi.Offset = DS.DestOffset;
   if (DestTi.Offset)
     calculateMemAddr(DestTi);
+  handleGlobalVar(DestTi);
 
   Src2Ti.Op = DS.Source2;
   Src2Ti.Offset = DS.Src2Offset;
@@ -797,7 +825,7 @@ bool llvm::crash_analyzer::TaintAnalysis::propagateTaint(
   if (SrcTi.Offset)
     calculateMemAddr(SrcTi);
 
-  bool SrcGlobalVar = handleGlobalVar(SrcTi);
+  bool SrcGlobalVar = handleGlobalVar(SrcTi) && DS.Source->isImm();
 
   Src2Ti.Op = DS.Source2;
   Src2Ti.Offset = DS.Src2Offset;
@@ -808,6 +836,7 @@ bool llvm::crash_analyzer::TaintAnalysis::propagateTaint(
   DestTi.Offset = DS.DestOffset;
   if (DestTi.Offset)
     calculateMemAddr(DestTi);
+  handleGlobalVar(DestTi);
 
   if (!DestTi.Op)
     return true;
@@ -862,6 +891,7 @@ bool llvm::crash_analyzer::TaintAnalysis::propagateTaint(
     SrcTi = ZeroTi;
     ConstantFound = true;
   }
+
   // Immediate operand, which is a symbol address for the global variable,
   // should not be treated as a constant.
   if (SrcGlobalVar)

--- a/llvm-15.0.3/llvm-crash-analyzer/llvm-crash-analyzer.cpp
+++ b/llvm-15.0.3/llvm-crash-analyzer/llvm-crash-analyzer.cpp
@@ -216,11 +216,6 @@ int main(int argc, char **argv) {
                                    PrintPotentialCrashCauseLocation);
   Dec->setTarget(&coreFile.getTarget());
 
-  // Set SBModule for Decompiler, so we can access the symbol table.
-  auto FileSpec = lldb::SBFileSpec(InputFilename.c_str());
-  auto LLDBModule = coreFile.getTarget().FindModule(FileSpec);
-  Dec->setSBModule(new lldb::SBModule(LLDBModule));
-
   TA.setDecompiler(Dec);
   TA.runOnBlameModule(BlameTrace);
 

--- a/llvm-15.0.3/llvm-crash-analyzer/test/Analysis/global-var-immediate.test
+++ b/llvm-15.0.3/llvm-crash-analyzer/test/Analysis/global-var-immediate.test
@@ -30,4 +30,4 @@
 # RUN: %S/Inputs/global-var-immediate.out --print-potential-crash-cause-loc < %s 2>&1 | FileCheck %s
 
 # CHECK: Blame Function is f
-# CHECK-NOT: From File {{.*}}/m.c:18:8
+# CHECK-NEXT: From File {{.*}}/glob.c:18:8

--- a/llvm-15.0.3/llvm-crash-analyzer/test/Analysis/rip-value-update.test
+++ b/llvm-15.0.3/llvm-crash-analyzer/test/Analysis/rip-value-update.test
@@ -5,7 +5,7 @@
 ##   *p = 0; // crash
 ## }
 ## int main() {
-##   p = 11; // blame point
+##   p = 11; // blame point - line 8
 ##   set();
 ##   return 0;
 ## }
@@ -20,11 +20,17 @@
 ## Confirm, for PC relative addressing mode, the same global variable address (GOT entry) is calculated at
 ## different program points.
 # RUN: %llvm-crash-analyzer --core-file=%S/Inputs/core.rip-value-update \
-# RUN:   %S/Inputs/rip-value-update.out -debug-only=taint-analysis < %s 2>&1 | FileCheck %s
+# RUN:   %S/Inputs/rip-value-update.out -debug-only=taint-analysis \
+# RUN:   --print-potential-crash-cause-loc < %s 2>&1 | FileCheck %s
 # CHECK: Add to TL: {reg:$rip; off:2099629} (mem addr: 6295520)
+
+## Confirm that proper blame line (and function) is reported.
+# CHECK: Blame Function is main
+# CHECK: From File {{.*}}/main.c:8:5
 
 # RUN: %llvm-crash-analyzer --core-file=%S/Inputs/core.rip-value-update \
 # RUN:   %S/Inputs/rip-value-update.out -debug-only=taint-analysis \
-# RUN:   -start-crash-order=2 -start-taint-reg=rax < %s 2>&1 | FileCheck %s --check-prefix=CHECK2
+# RUN:   -start-crash-order=2 -start-taint-reg=rax \
+# RUN:   --print-potential-crash-cause-loc < %s 2>&1 | FileCheck %s --check-prefix=CHECK2
 
 # CHECK2: Add to TL: {reg:$rip; off:2099594} (mem addr: 6295520)


### PR DESCRIPTION
This PR improves global variables support.
The `handleGlobalVar` function checks if TaintInfo represents a global variable
and converts Ti into expected form. Expected form is $noreg plus offset, 
which is the global variable symbol address or the Global Offset Table entry.
Also, all `SBModule`s, needed for searching global symbols, is derived from Decompiler's
`SBTarget`, which make us able to search symbols from all dependencies.

In Decompiled MIR, Global variables are represented by three different types of operands:
1. Immediate operands – value is global symbol address 
```
$rdi = MOV64ri 6295592
```

2. Memory operand `$noreg + offset` – offset is the global symbol address 
```
MOV64mi32 $noreg, 1, $noreg, 6295592, $noreg, 0
```

3. PC relative address – address of the global variable entry in the GOT (Global Offset Table), where the variable address is stored (extra level of indirection)
```
   $rax = MOV64rm $rip, 1, $noreg, 2099639, $noreg
    MOV64mr $rax, 1, $noreg, 0, $noreg, $rcx
```

RegisterEquivalence is improved to transform PC relative address into `$noreg + offset` format, which is beneficial for correct calculation of Concrete Memory Address when backup (equivalent) location is used.