### PR TITLE
Ensure debuggee process launch when core-file is specified

### DIFF
--- a/llvm-15.0.3/lldb/tools/lldb-crash-server/lldb-gdbserver.cpp
+++ b/llvm-15.0.3/lldb/tools/lldb-crash-server/lldb-gdbserver.cpp
@@ -481,11 +481,14 @@ int main_gdbserver(int argc, char *argv[]) {
   // explicitly asked to attach with the --attach={pid|program_name} form.
   if (!attach_target.empty())
     handle_attach(gdb_server, attach_target);
-  else if (!core_file.empty())
-    handle_core(gdb_server, core_file, sysroot, module_path,
-                solib_path, Inputs);
   else if (!Inputs.empty())
     handle_launch(gdb_server, Inputs);
+
+  // TODO: If debuggee process is launched, try to set the target execution
+  // context, with the information from the core-file.
+  if (!core_file.empty())
+    handle_core(gdb_server, core_file, sysroot, module_path, solib_path,
+                Inputs);
 
   // Print version info.
   printf("%s-%s\n", LLGS_PROGRAM_NAME, LLGS_VERSION_STR);


### PR DESCRIPTION
## Description

Ensure setup of debug session when `--core-file` argument is used for remote debugging via lldb-crash-server.
This patch fixes lldb-crash-server to launch debuggee process when core-file needs to be loaded.
Confirmed that lldb-crash-server is working as debugserver with both LLDB and GDB as clients.

TODO: If debuggee process is launched, try to set the target execution context, with the information loaded from the core-file.

## Type of Change

- Bug Fix
