### PR TITLE
[lldb-crash-server] Add minimal support for reading memory

### DIFF
--- a/llvm-15.0.3/lldb/tools/lldb-crash-server/CoreFileProtocol.cpp
+++ b/llvm-15.0.3/lldb/tools/lldb-crash-server/CoreFileProtocol.cpp
@@ -33,6 +33,19 @@ CoreFileProtocol::CoreFileProtocol(::pid_t pid,
   SetState(lldb::StateType::eStateStopped, false);
 }
 
+Status CoreFileProtocol::ReadMemory(lldb::addr_t addr, void *buf, size_t size,
+                                    size_t &bytes_read) {
+  // Read memory from the core-file process.
+  lldb::SBError error;
+  bytes_read = m_corefile.getProcess().ReadMemory(addr, buf, size, error);
+  if (error.Fail() || bytes_read != size) {
+    return Status("Failed to read %zu bytes at addr=0x%" PRIx64
+                  " from the core-file process",
+                  size, addr);
+  }
+  return Status();
+}
+
 llvm::Expected<std::unique_ptr<CoreFileProtocol>>
 CoreFileProtocol::Factory::Read(lldb::crash_analyzer::CoreFile &corefile, 
                                 NativeProcessProtocol::NativeDelegate &native_delegate,

--- a/llvm-15.0.3/lldb/tools/lldb-crash-server/CoreFileProtocol.h
+++ b/llvm-15.0.3/lldb/tools/lldb-crash-server/CoreFileProtocol.h
@@ -32,7 +32,7 @@ public:
   Status Kill() override { return Status(); }
 
   Status ReadMemory(lldb::addr_t addr, void *buf, size_t size,
-                    size_t &bytes_read) override { return Status(); }
+                    size_t &bytes_read) override;
 
   Status WriteMemory(lldb::addr_t addr, const void *buf, size_t size,
                      size_t &bytes_written) override { return Status(); }


### PR DESCRIPTION
## Description

Intercept memory reads on the lldb-crash-server side to access memory context from the core-file process.
That is done by overriding the `ReadMemory` method of the `CoreFileProtocol`, a derivate of `NativeProcessProtocol`.

## Test example

TARGET:
```
$ lldb-crash-server g --core-file core.m localhost:1234 ./m
Loading core-file core.m
warning: No debugging symbols found in libc.so.6
core-file processed.

lldb-server-local_build
Connection established.
```

HOST:
```
$ gdb
GNU gdb (GDB) 14.0.50.20230607-git
...
(gdb) set architecture i386:x86-64
The target architecture is set to "i386:x86-64".
(gdb) target remote localhost:1234
Remote debugging using localhost:1234
warning: while parsing target description (at line 1): Target description specified unknown architecture "x86_64"
warning: Could not load XML target description; ignoring
warning: No executable has been specified and target does not support
determining executable automatically.  Try using the "file" command.
0x0000000000400550 in ?? ()
(gdb) symbol-file ./m
Reading symbols from ./m...
(gdb) bt
#0  0x0000000000400550 in crash (str=0x7fffa0920688) at m.c:7
#1  0x000000000040058f in main () at m.c:16
(gdb) disassemble
Dump of assembler code for function crash:
   0x0000000000400540 <+0>:     push   %rbp
   0x0000000000400541 <+1>:     mov    %rsp,%rbp
   0x0000000000400544 <+4>:     mov    %rdi,-0x8(%rbp)
   0x0000000000400548 <+8>:     mov    -0x8(%rbp),%rax
   0x000000000040054c <+12>:    mov    0x8(%rax),%rax
=> 0x0000000000400550 <+16>:    movl   $0x4,(%rax)
   0x0000000000400556 <+22>:    pop    %rbp
   0x0000000000400557 <+23>:    ret
```

CORE-FILE LOADED BY GDB:
```
$ gdb
GNU gdb (GDB) 14.0.50.20230607-git
Reading symbols from ./m...
[New LWP 2852139]
Core was generated by `./m'.
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x0000000000400550 in crash (str=0x7fffa0920688) at m.c:7
7         *str->x = 4; // crash - line 7
(gdb) bt
#0  0x0000000000400550 in crash (str=0x7fffa0920688) at m.c:7
#1  0x000000000040058f in main () at m.c:16
(gdb) disassemble
Dump of assembler code for function crash:
   0x0000000000400540 <+0>:     push   %rbp
   0x0000000000400541 <+1>:     mov    %rsp,%rbp
   0x0000000000400544 <+4>:     mov    %rdi,-0x8(%rbp)
   0x0000000000400548 <+8>:     mov    -0x8(%rbp),%rax
   0x000000000040054c <+12>:    mov    0x8(%rax),%rax
=> 0x0000000000400550 <+16>:    movl   $0x4,(%rax)
   0x0000000000400556 <+22>:    pop    %rbp
   0x0000000000400557 <+23>:    ret
End of assembler dump.
```