### PR TITLE
Adding gdb testcases to the project.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Steps:
     $ $ cmake -G "Ninja" -DLLVM_ENABLE_PROJECTS="clang;llvm-crash-analyzer;lldb;" -DLLVM_ENABLE_LIBCXX=ON ../llvm-crash-analyzer/llvm-10.0.1/llvm -DLLDB_TEST_COMPILER=clang -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=clang-12 -DCMAKE_CXX_COMPILER=clang++-12 -DLLVM_ENABLE_ASSERTIONS=ON
     $ make && make check-llvm-crash-analyzer
 
+For LLDBServerWithGDB tests to work, we need to add "-DLLDB_SERVER_GDB_TEST_PATH=/path/to/gdb" option.
+
 ## Using the tool
 
 1) help:

--- a/llvm-15.0.3/llvm-crash-analyzer/CMakeLists.txt
+++ b/llvm-15.0.3/llvm-crash-analyzer/CMakeLists.txt
@@ -2,6 +2,7 @@ set(CRASH_ANALYZER_MAIN_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}) # --src-root
 set(CRASH_ANALYZER_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/include ) # --includedir
 set(CRASH_ANALYZER_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 set(CRASH_ANALYZER_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
+option(LLDB_SERVER_GDB_TEST_PATH "Path to GDB for testing" "")
 
 include_directories(include/
                     ${LLVM_MAIN_INCLUDE_DIR}/
@@ -11,6 +12,10 @@ add_subdirectory(lib)
 add_subdirectory(test)
 add_subdirectory(tools)
 add_subdirectory(unittests)
+
+if(LLDB_SERVER_GDB_TEST_PATH)
+  add_definitions(-DLLDB_SERVER_GDB_TEST_PATH="${LLDB_SERVER_GDB_TEST_PATH}")
+endif()
 
 set(LLVM_LINK_COMPONENTS
   AllTargetsCodeGens

--- a/llvm-15.0.3/llvm-crash-analyzer/test/LLDBServerWithGDB/auxv-gc.gdb
+++ b/llvm-15.0.3/llvm-crash-analyzer/test/LLDBServerWithGDB/auxv-gc.gdb
@@ -1,0 +1,5 @@
+set print sevenbit-strings
+break 70
+run
+gcore ./Output/auxv.core
+quit

--- a/llvm-15.0.3/llvm-crash-analyzer/test/LLDBServerWithGDB/auxv-gdb.gdb
+++ b/llvm-15.0.3/llvm-crash-analyzer/test/LLDBServerWithGDB/auxv-gdb.gdb
@@ -1,0 +1,3 @@
+set pagination off
+info auxv
+quit

--- a/llvm-15.0.3/llvm-crash-analyzer/test/LLDBServerWithGDB/auxv.c
+++ b/llvm-15.0.3/llvm-crash-analyzer/test/LLDBServerWithGDB/auxv.c
@@ -1,0 +1,83 @@
+// RUN: %clang -g %s -o %t
+// RUN: %gdb -q -x %S/auxv-gc.gdb %t
+// RUN: bash -c "%lldb-crash-server g --core-file %T/auxv.core localhost:1234 %t > /dev/null 2>&1 &"
+// RUN: sleep 1
+// RUN: %gdb -q -x %S/auxv.gdb %t | sed -n '/ABORT/,/End of vector/p' > %T/gdb-with-lldb-output.txt
+// RUN: %gdb -q -x %S/auxv-gdb.gdb %t %T/auxv.core | sed -n '/ABORT/,/End of vector/p' > %T/gdb-direct-output.txt
+// RUN: diff -s %T/gdb-with-lldb-output.txt %T/gdb-direct-output.txt | FileCheck %s
+
+// CHECK: are identical
+// CHECK-NOT: <
+// CHECK-NOT: >
+// CHECK-NOT: ---
+
+#ifndef __STDC__
+#define	const	/**/
+#endif
+
+#ifndef HAVE_ABORT
+#define HAVE_ABORT 1
+#endif
+
+#if HAVE_ABORT
+#include <stdlib.h>
+#define ABORT abort()
+#else
+#define ABORT {char *invalid = 0; *invalid = 0xFF;}
+#endif
+
+#ifdef USE_RLIMIT
+# include <sys/resource.h>
+# ifndef RLIM_INFINITY
+#  define RLIM_INFINITY -1
+# endif
+#endif /* USE_RLIMIT */
+
+/* Don't make these automatic vars or we will have to walk back up the
+   stack to access them. */
+
+char *buf1;
+char *buf2;
+
+int coremaker_data = 1;	/* In Data section */
+int coremaker_bss;	/* In BSS section */
+
+const int coremaker_ro = 201;	/* In Read-Only Data section */
+
+void
+func2 (int x)
+{
+  int coremaker_local[5];
+  int i;
+  static int y;
+
+#ifdef USE_RLIMIT
+  {
+    struct rlimit rlim = { RLIM_INFINITY, RLIM_INFINITY };
+
+    setrlimit (RLIMIT_CORE, &rlim);
+  }
+#endif
+
+  /* Make sure that coremaker_local doesn't get optimized away. */
+  for (i = 0; i < 5; i++)
+    coremaker_local[i] = i;
+  coremaker_bss = 0;
+  for (i = 0; i < 5; i++)
+    coremaker_bss += coremaker_local[i];
+  coremaker_data = coremaker_ro + 1;
+  y = 10 * x;
+  ABORT;
+}
+
+void
+func1 (int x)
+{
+  func2 (x * 2);
+}
+
+int main ()
+{
+  func1 (10);
+  return 0;
+}

--- a/llvm-15.0.3/llvm-crash-analyzer/test/LLDBServerWithGDB/auxv.gdb
+++ b/llvm-15.0.3/llvm-crash-analyzer/test/LLDBServerWithGDB/auxv.gdb
@@ -1,0 +1,4 @@
+set pagination off
+target remote localhost:1234
+info auxv
+quit

--- a/llvm-15.0.3/llvm-crash-analyzer/test/LLDBServerWithGDB/lit.local.cfg
+++ b/llvm-15.0.3/llvm-crash-analyzer/test/LLDBServerWithGDB/lit.local.cfg
@@ -1,0 +1,4 @@
+if config.gdb_test_path and config.gdb_test_path != "OFF":
+    config.substitutions.append(('%gdb', config.gdb_test_path))
+else:
+    config.unsupported = True

--- a/llvm-15.0.3/llvm-crash-analyzer/test/LLDBServerWithGDB/vdso-warning-gc.gdb
+++ b/llvm-15.0.3/llvm-crash-analyzer/test/LLDBServerWithGDB/vdso-warning-gc.gdb
@@ -1,0 +1,5 @@
+break main
+set environment LD_DEBUG=unused
+run
+gcore ./Output/vdso-warning.core
+quit

--- a/llvm-15.0.3/llvm-crash-analyzer/test/LLDBServerWithGDB/vdso-warning.c
+++ b/llvm-15.0.3/llvm-crash-analyzer/test/LLDBServerWithGDB/vdso-warning.c
@@ -1,0 +1,17 @@
+// RUN: %clang -g %s -o %t
+// RUN: %gdb -q -x %S/vdso-warning-gc.gdb %t
+// RUN: bash -c "%lldb-crash-server g --core-file %T/vdso-warning.core localhost:1234 %t > /dev/null 2>&1 &"
+// RUN: sleep 1
+// RUN: %gdb -q -x %S/vdso-warning.gdb %t 2>&1 | FileCheck %s
+
+// CHECK-NOT: Could not load shared library symbols
+// CHECK: main ()
+
+// CHECK-NOT: No{{[[:space:]]*}}linux-vdso.so.1
+// CHECK-NOT: No{{[[:space:]]*}}linux-gate.so.1
+
+
+int main (void)
+{
+    return 0;
+}

--- a/llvm-15.0.3/llvm-crash-analyzer/test/LLDBServerWithGDB/vdso-warning.gdb
+++ b/llvm-15.0.3/llvm-crash-analyzer/test/LLDBServerWithGDB/vdso-warning.gdb
@@ -1,0 +1,4 @@
+set pagination off
+target remote localhost:1234
+info shared
+quit

--- a/llvm-15.0.3/llvm-crash-analyzer/test/lit.cfg.py
+++ b/llvm-15.0.3/llvm-crash-analyzer/test/lit.cfg.py
@@ -73,6 +73,8 @@ llvm_config.with_environment('PATH', config.llvm_tools_dir, append_path=True)
 tool_dirs = [config.llvm_tools_dir]
 
 tools = [ToolSubst('%llvm-crash-analyzer', command=FindTool('llvm-crash-analyzer'), unresolved='fatal'),
-         ToolSubst('%llvm-crash-analyzer-ta', command=FindTool('llvm-crash-analyzer-ta'), unresolved='fatal')]
+         ToolSubst('%llvm-crash-analyzer-ta', command=FindTool('llvm-crash-analyzer-ta'), unresolved='fatal'),
+         ToolSubst('%lldb-crash-server', command=FindTool('lldb-crash-server'), unresolved='fatal'),
+         ToolSubst('%clang', command=FindTool('clang'), unresolved='fatal')]
 
 llvm_config.add_tool_substitutions(tools, tool_dirs)

--- a/llvm-15.0.3/llvm-crash-analyzer/test/lit.site.cfg.py.in
+++ b/llvm-15.0.3/llvm-crash-analyzer/test/lit.site.cfg.py.in
@@ -30,6 +30,7 @@ config.llvm_host_triple = '@LLVM_HOST_TRIPLE@'
 config.host_arch = "@HOST_ARCH@"
 config.crash_analyzer_src_dir = "@CRASH_ANALYZER_SOURCE_DIR@"
 config.crash_analyzer_obj_root = "@CRASH_ANALYZER_BINARY_DIR@"
+config.gdb_test_path = "@LLDB_SERVER_GDB_TEST_PATH@"
 
 # Support substitution of the tools_dir with user parameters. This is
 # used when we can't determine the tool dir at configuration time.


### PR DESCRIPTION
For tests to work we should add -DLLDB_SERVER_GDB_TEST_PATH=path/to/gdb option when building the tool.

- Setup environment for crash-server/gdb testing
- Create "vdso-warning" and "auxv" tests
- Update README file

 Still need to add rest of the testcases