### PR TITLE
Adding Uncore execution and attaching to uncored live process.

### DIFF
--- a/llvm-15.0.3/lldb/tools/lldb-crash-server/CMakeLists.txt
+++ b/llvm-15.0.3/lldb/tools/lldb-crash-server/CMakeLists.txt
@@ -2,6 +2,9 @@ set(LLVM_TARGET_DEFINITIONS LLGSOptions.td)
 tablegen(LLVM LLGSOptions.inc -gen-opt-parser-defs)
 add_public_tablegen_target(LLCSOptionsTableGen)
 set_target_properties(LLGSOptionsTableGen PROPERTIES FOLDER "lldb misc")
+set(UNCORE_PATH CACHE STRING "Path to Uncore tool")
+
+add_definitions(-DUNCORE_PATH="${UNCORE_PATH}")
 
 set(LLDB_PLUGINS)
 
@@ -50,6 +53,7 @@ add_lldb_tool(lldb-crash-server
     CoreThreadProtocol.cpp
     CoreRegisterContext.cpp
     CoreRegisterContext_x86_64.cpp
+    UncoreHandler.cpp
 
     LINK_LIBS
       lldbHost

--- a/llvm-15.0.3/lldb/tools/lldb-crash-server/LLGSOptions.td
+++ b/llvm-15.0.3/lldb/tools/lldb-crash-server/LLGSOptions.td
@@ -48,6 +48,10 @@ defm core_file: SJ<"core-file", "The core file to analyse.">,
   MetaVarName<"<path-to-corefile>">,
   Group<grp_general>;
 
+defm uncore_json: SJ<"uncore-json", "JSON file to be used by Uncore.">,
+  MetaVarName<"<path-to-uncore-json>">,
+  Group<grp_general>;
+
 defm sysroot: SJ<"sysroot", "system root path.">,
   MetaVarName<"<sysroot>">,
   Group<grp_general>;

--- a/llvm-15.0.3/lldb/tools/lldb-crash-server/UncoreHandler.cpp
+++ b/llvm-15.0.3/lldb/tools/lldb-crash-server/UncoreHandler.cpp
@@ -1,0 +1,68 @@
+#include <cstdio>
+#include <iostream>
+#include <memory>
+#include <regex>
+
+#include "UncoreHandler.h"
+
+using namespace llvm;
+using namespace lldb;
+
+bool lldb::UncoreHandler::RunUncore() {
+  std::string cmd =
+      m_uncore_path + " -c " + m_uncore_json + " > /dev/null 2>&1";
+
+  int status = std::system(cmd.c_str());
+
+  if (status != 0) {
+    llvm::errs() << "Uncore execution failed.\n";
+    return false;
+  }
+
+  return true;
+}
+
+// TODO handle killing loader.bin in case of unexpected termination
+std::pair<::pid_t, std::string> lldb::UncoreHandler::RunLoaderProcess() {
+  std::string cmd = m_working_dir + "/outdir/loader.bin " + m_working_dir +
+                    "/outdir/core.ctx loop &";
+
+  m_pipe.reset(popen(cmd.c_str(), "r"));
+
+  if (!m_pipe) {
+    llvm::errs() << "Failed to run laoder.bin. \n";
+    return std::make_pair(LLDB_INVALID_PROCESS_ID, "");
+  }
+
+  std::string line, result = "";
+  char ch;
+
+  while (fread(&ch, 1, 1, m_pipe.get())) {
+    line += ch;
+    if (ch == '\n') {
+      if (line.find(" continue") != std::string::npos)
+        break;
+      result += line;
+      line.clear();
+    }
+  }
+
+  std::regex attach_regex("attach (0x[0-9a-fA-F]+)");
+  std::regex set_regex("\\(gdb\\) set \\*\\(\\(int\\*\\).*");
+  std::smatch matches;
+
+  ::pid_t pid = LLDB_INVALID_PROCESS_ID;
+  std::string set_cmd;
+
+  if (std::regex_search(result, matches, attach_regex) && matches.size() > 1) {
+    std::string pid_str = matches[1];
+    unsigned long long_pid = strtoul(pid_str.c_str(), nullptr, 16);
+    pid = static_cast<::pid_t>(long_pid);
+  }
+
+  if (std::regex_search(result, matches, set_regex) && matches.size() > 0) {
+    set_cmd = matches[0];
+  }
+
+  return std::make_pair(pid, set_cmd);
+}

--- a/llvm-15.0.3/lldb/tools/lldb-crash-server/UncoreHandler.h
+++ b/llvm-15.0.3/lldb/tools/lldb-crash-server/UncoreHandler.h
@@ -1,0 +1,36 @@
+#include <cstdio>
+#include <filesystem>
+#include <memory>
+
+#include "lldb/Host/FileSystem.h"
+#include "llvm/ADT/SmallString.h"
+
+#ifdef UNCORE_PATH
+
+using namespace llvm;
+
+namespace lldb {
+class UncoreHandler {
+  const std::string m_uncore_path = UNCORE_PATH;
+  std::string m_working_dir;
+  std::string m_uncore_json;
+  std::unique_ptr<FILE, decltype(&pclose)> m_pipe;
+
+public:
+  UncoreHandler(std::string uncore_json) : m_pipe(nullptr, pclose) {
+    m_uncore_json = uncore_json;
+    llvm::SmallString<64> cwd;
+    if (std::error_code ec = llvm::sys::fs::current_path(cwd)) {
+      llvm::errs() << "Error getting current directory: " << ec.message()
+                   << "\n";
+      exit(1);
+    }
+    m_working_dir = cwd.str().data();
+  }
+
+  bool RunUncore();
+  std::pair<::pid_t, std::string> RunLoaderProcess();
+};
+} // namespace lldb
+
+#endif


### PR DESCRIPTION
- If we want to use Uncore and uncored process, we should use "--uncore-json <path-to-json>" option when running Crash server (instead of --core-file).
- Also, we should add "-UNCORE_PATH" option during build configuration.
- When attached to a uncored process, gdb set command will be displayed for client side (required to break the loader.bin loop).

* Fix problem with attaching to PID in hexadecimal format.
* Uncore execution on corefile specified in json file.
* Attaching to uncored process.
* Add Uncore path build option and json file option.

